### PR TITLE
Add Makefile and improve CLI usage documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,10 @@ jobs:
           command: |
             VERSION=${CIRCLE_TAG:-dev}
             COMMIT=${CIRCLE_SHA1:-unknown}
-            BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+            BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
             GO_VERSION=$(go version | awk '{print $3}')
-            LDFLAGS="-X 'main.Version=$VERSION' -X 'main.Commit=$COMMIT' -X 'main.BuildTime=$BUILD_TIME' -X 'main.GoVersion=$GO_VERSION'"
             
-            go build -v -ldflags "$LDFLAGS" -o bin/sysml ./cmd/sysml
-            go build -v -ldflags "$LDFLAGS" -o bin/sysml-lsp ./cmd/sysml-lsp
+            make build VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
       
       - run:
           name: Verify binaries
@@ -64,28 +62,43 @@ jobs:
       - run:
           name: Build release binaries
           command: |
-            # Create dist directory
-            mkdir -p dist
-            
-            # Get build metadata
             VERSION=${CIRCLE_TAG}
             COMMIT=${CIRCLE_SHA1}
-            BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+            BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
             GO_VERSION=$(go version | awk '{print $3}')
-            LDFLAGS="-X 'main.Version=$VERSION' -X 'main.Commit=$COMMIT' -X 'main.BuildTime=$BUILD_TIME' -X 'main.GoVersion=$GO_VERSION'"
             
-            # Build for multiple platforms
-            GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/sysml-linux-amd64 ./cmd/sysml
-            GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/sysml-linux-arm64 ./cmd/sysml
-            GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/sysml-darwin-amd64 ./cmd/sysml
-            GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/sysml-darwin-arm64 ./cmd/sysml
-            GOOS=windows GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/sysml-windows-amd64.exe ./cmd/sysml
+            # Build for multiple platforms using make
+            mkdir -p dist
             
-            GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/sysml-lsp-linux-amd64 ./cmd/sysml-lsp
-            GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/sysml-lsp-linux-arm64 ./cmd/sysml-lsp
-            GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/sysml-lsp-darwin-amd64 ./cmd/sysml-lsp
-            GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/sysml-lsp-darwin-arm64 ./cmd/sysml-lsp
-            GOOS=windows GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/sysml-lsp-windows-amd64.exe ./cmd/sysml-lsp
+            GOOS=linux GOARCH=amd64 make build-sysml VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml dist/sysml-linux-amd64
+            
+            GOOS=linux GOARCH=arm64 make build-sysml VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml dist/sysml-linux-arm64
+            
+            GOOS=darwin GOARCH=amd64 make build-sysml VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml dist/sysml-darwin-amd64
+            
+            GOOS=darwin GOARCH=arm64 make build-sysml VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml dist/sysml-darwin-arm64
+            
+            GOOS=windows GOARCH=amd64 make build-sysml VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml dist/sysml-windows-amd64.exe
+            
+            GOOS=linux GOARCH=amd64 make build-lsp VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml-lsp dist/sysml-lsp-linux-amd64
+            
+            GOOS=linux GOARCH=arm64 make build-lsp VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml-lsp dist/sysml-lsp-linux-arm64
+            
+            GOOS=darwin GOARCH=amd64 make build-lsp VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml-lsp dist/sysml-lsp-darwin-amd64
+            
+            GOOS=darwin GOARCH=arm64 make build-lsp VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml-lsp dist/sysml-lsp-darwin-arm64
+            
+            GOOS=windows GOARCH=amd64 make build-lsp VERSION="$VERSION" COMMIT="$COMMIT" BUILD_TIME="$BUILD_TIME" GO_VERSION="$GO_VERSION"
+            mv bin/sysml-lsp dist/sysml-lsp-windows-amd64.exe
             
             # Create tarballs
             cd dist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,25 +6,45 @@ Thank you for your interest in contributing to Systemica!
 
 ### Prerequisites
 
-- Go 1.25 or later
+- Go 1.23 or later
 - Git
-- Make (optional, for build automation)
+- Make (recommended for build automation)
 
 ### Clone and Build
 
 ```bash
 git clone https://github.com/Open-MBEE/Systemica.git
 cd Systemica
-go build ./...
-go test ./...
+make build  # builds bin/sysml and bin/sysml-lsp with version info
+make test   # runs all tests
 ```
 
 ## Development Workflow
 
+### Building
+
+```bash
+# Build all binaries with version info
+make build
+
+# Build specific binary
+make build-sysml
+make build-lsp
+
+# Install to $GOPATH/bin
+make install
+
+# Clean build artifacts
+make clean
+```
+
 ### Running Tests
 
 ```bash
-# All tests
+# All tests (using Makefile)
+make test
+
+# All tests (direct)
 go test ./...
 
 # With coverage
@@ -33,6 +53,9 @@ go tool cover -html=coverage.out
 
 # With race detector
 go test -race ./...
+
+# Short tests (faster, no race detector)
+make test-short
 
 # Specific package
 go test ./internal/core/parser

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+.PHONY: all build build-sysml build-lsp test clean install help
+
+# Version information
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME ?= $(shell date -u '+%Y-%m-%d_%H:%M:%S')
+GO_VERSION ?= $(shell go version | awk '{print $$3}')
+
+# Build flags
+LDFLAGS := -X main.Version=$(VERSION) \
+           -X main.Commit=$(COMMIT) \
+           -X main.BuildTime=$(BUILD_TIME) \
+           -X main.GoVersion=$(GO_VERSION)
+
+# Build output directory
+BIN_DIR := bin
+
+all: build test ## Build and test everything
+
+build: build-sysml build-lsp ## Build all binaries
+
+build-sysml: ## Build sysml binary
+	@echo "Building sysml..."
+	@mkdir -p $(BIN_DIR)
+	go build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/sysml ./cmd/sysml
+	@echo "✓ Built $(BIN_DIR)/sysml ($(VERSION))"
+
+build-lsp: ## Build sysml-lsp binary
+	@echo "Building sysml-lsp..."
+	@mkdir -p $(BIN_DIR)
+	go build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/sysml-lsp ./cmd/sysml-lsp
+	@echo "✓ Built $(BIN_DIR)/sysml-lsp ($(VERSION))"
+
+test: ## Run all tests
+	@echo "Running tests..."
+	go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+test-short: ## Run tests without race detector (faster)
+	@echo "Running tests (short)..."
+	go test -v ./...
+
+clean: ## Remove build artifacts
+	@echo "Cleaning..."
+	rm -rf $(BIN_DIR)
+	rm -f coverage.txt
+	rm -f sysml sysml-lsp
+	@echo "✓ Cleaned"
+
+install: build ## Install binaries to $GOPATH/bin
+	@echo "Installing to $(shell go env GOPATH)/bin..."
+	go install -ldflags "$(LDFLAGS)" ./cmd/sysml
+	go install -ldflags "$(LDFLAGS)" ./cmd/sysml-lsp
+	@echo "✓ Installed"
+
+version: ## Show version information
+	@echo "Version:    $(VERSION)"
+	@echo "Commit:     $(COMMIT)"
+	@echo "Build time: $(BUILD_TIME)"
+	@echo "Go version: $(GO_VERSION)"
+
+help: ## Show this help message
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ tar xzf sysml-linux-amd64.tar.gz && sudo mv sysml-linux-amd64 /usr/local/bin/sys
 
 **Or build from source:**
 ```bash
-go build -o sysml ./cmd/sysml
-./sysml
+make build
+./bin/sysml
 ```
 
 ### Try it

--- a/cmd/sysml/main.go
+++ b/cmd/sysml/main.go
@@ -55,6 +55,17 @@ func (s *stringSlice) Set(value string) error {
 }
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: sysml [options] [file...]\n\n")
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\nExamples:\n")
+		fmt.Fprintf(os.Stderr, "  sysml                     # Start interactive REPL\n")
+		fmt.Fprintf(os.Stderr, "  sysml -e \"5 + 3\"          # Evaluate and exit\n")
+		fmt.Fprintf(os.Stderr, "  sysml -e \"expr\" file.sysml # Load file, evaluate, and exit\n")
+		fmt.Fprintf(os.Stderr, "  sysml file.sysml          # Load file and start REPL\n")
+	}
+	
 	flag.Var(&evalExprs, "eval", "Evaluate expression and exit (can be specified multiple times)")
 	flag.Var(&evalExprs, "e", "Evaluate expression and exit (shorthand)")
 	flag.BoolVar(&showVersion, "version", false, "Show version information")

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -42,20 +42,25 @@ Download `sysml-windows-amd64.zip` from [releases](https://github.com/Open-MBEE/
 ### Option 2: Build from Source
 
 **Prerequisites:**
-- Go 1.25 or later
+- Go 1.23 or later
 - Git
+- Make (optional but recommended)
 
 **Build:**
 ```bash
 git clone https://github.com/Open-MBEE/Systemica.git
 cd Systemica
+make build       # builds bin/sysml and bin/sysml-lsp
+# OR
 go build -o sysml ./cmd/sysml
 go build -o sysml-lsp ./cmd/sysml-lsp
 ```
 
 **Install (optional):**
 ```bash
-sudo mv sysml sysml-lsp /usr/local/bin/
+make install     # installs to $GOPATH/bin
+# OR
+sudo mv bin/sysml bin/sysml-lsp /usr/local/bin/
 ```
 
 ---

--- a/examples/CLI_USAGE.md
+++ b/examples/CLI_USAGE.md
@@ -8,33 +8,43 @@ Start the REPL with no arguments:
 sysml
 ```
 
+Load files and enter interactive mode:
+
+```bash
+sysml model.sysml
+sysml types.sysml instances.sysml
+```
+
 ## Non-Interactive Mode
 
-Execute commands and exit without entering interactive mode.
+Execute expressions and exit without entering interactive mode.
 
 ### Basic Evaluation
 
-Load a model and evaluate an expression:
+Evaluate an expression:
 
 ```bash
-sysml --load model.sysml --eval someAttribute
-# Output: value of someAttribute
+sysml -e "5 + 3"
+# Output: ✓ 5 + 3
+#           = 8
 ```
 
-### Short Flags
+### Load Files and Evaluate
 
-Use abbreviated flags for convenience:
+Load a model first, then evaluate:
 
 ```bash
-sysml -l model.sysml -e x
+sysml -e "someAttribute" model.sysml
 ```
+
+**Note:** Options (`-e`) must come BEFORE positional arguments (files).
 
 ### Multiple Evaluations
 
 Evaluate multiple expressions in sequence:
 
 ```bash
-sysml -l model.sysml -e x -e y -e z
+sysml -e "x" -e "y" -e "z" model.sysml
 ```
 
 ### Multiple Files
@@ -42,52 +52,51 @@ sysml -l model.sysml -e x -e y -e z
 Load multiple files before evaluating:
 
 ```bash
-sysml -l types.sysml -l instances.sysml -e result
-```
-
-### Quiet Mode
-
-Suppress prompts and decorations for clean output (useful for scripting):
-
-```bash
-sysml --quiet --load model.sysml --eval result
-# Output: only the value
-
-sysml -q -l model.sysml -e output > result.txt
+sysml -e "result" types.sysml instances.sysml
 ```
 
 ## Real-World Examples
 
-### 1. Validate Model and Check Constraint
+### 1. Quick Calculation
 
 ```bash
-sysml -l vehicle-model.sysml -e "speedLimit < 120"
+sysml -e "10 * 2 + 5"
+# Output: ✓ 10 * 2 + 5
+#           = 25
 ```
 
-### 2. Extract Calculated Values
+### 2. Validate Model and Check Constraint
+
+```bash
+sysml -e "speedLimit < 120" vehicle-model.sysml
+```
+
+### 3. Extract Calculated Values
 
 ```bash
 # model.sysml contains: attribute totalCost = partCost + laborCost;
-sysml -q -l model.sysml -e totalCost
-# Output: 1500.00
+sysml -e "totalCost" model.sysml
+# Output: ✓ totalCost
+#           = 1500.00
 ```
 
-### 3. Batch Processing
+### 4. Batch Processing
 
 ```bash
 #!/bin/bash
 for model in models/*.sysml; do
-    result=$(sysml -q -l "$model" -e result)
+    result=$(sysml -e "result" "$model" 2>&1 | grep "=" | awk '{print $2}')
     echo "$model: $result"
 done
 ```
 
-### 4. CI/CD Integration
+### 5. CI/CD Integration
 
 ```bash
 # Check that calculated value matches expected
 expected=42
-actual=$(sysml -q -l design.sysml -e designParameter)
+output=$(sysml -e "designParameter" design.sysml)
+actual=$(echo "$output" | grep "=" | awk '{print $2}')
 if [ "$actual" = "$expected" ]; then
     echo "✓ Design parameter validated"
     exit 0
@@ -97,83 +106,105 @@ else
 fi
 ```
 
-### 5. Semantic Layer Demo
+### 6. Use REPL Meta Commands
+
+Load a file and use meta commands:
 
 ```bash
-# Evaluate operators and expressions
-sysml -l examples/semantic-layer/demo.sysml -e intEquality -e usePi -e expr1
-
-# Quiet mode for scripting
-sysml -q -l examples/semantic-layer/demo.sysml -e intEquality
-# Output:   = true
+echo "%load model.sysml
+%instantiate Vehicle
+%slots Vehicle
+%eval speedLimit" | sysml
 ```
 
 ## Command Reference
 
 | Flag | Shorthand | Description |
 |------|-----------|-------------|
-| `--load <file>` | `-l` | Load a SysML file (repeatable) |
-| `--eval <expr>` | `-e` | Evaluate an expression (repeatable) |
-| `--quiet` | `-q` | Suppress prompts and decorations |
+| `--eval <expr>` | `-e` | Evaluate expression and exit (repeatable) |
 | `--version` | `-v` | Show version information |
-| `--help` | | Show usage information |
+| `--help` | `-h` | Show usage information |
 
-## Output Modes
+**Arguments:**
+- `[file...]` - SysML files to load (loaded in order)
 
-### Normal Mode (default)
-
-Includes prompts, checkmarks, and decorative output:
-
-```bash
-$ sysml -l demo.sysml -e x
-package Demo
-✓ x
-  = 42
+**Usage pattern:**
+```
+sysml [options] [file...]
 ```
 
-### Quiet Mode
-
-Only essential output:
+## Examples
 
 ```bash
-$ sysml -q -l demo.sysml -e x
-  = 42
+# Interactive REPL
+sysml
+
+# Load file and start REPL
+sysml model.sysml
+
+# Evaluate and exit
+sysml -e "5 + 3"
+
+# Load file, evaluate, and exit
+sysml -e "expr" file.sysml
+
+# Multiple evaluations
+sysml -e "x" -e "y" file.sysml
+
+# Multiple files
+sysml -e "result" file1.sysml file2.sysml
+```
+
+## Output Format
+
+All evaluations include checkmark and result:
+
+```bash
+$ sysml -e "10 * 2"
+✓ 10 * 2
+  = 20
+```
+
+For file loads, declarations are summarized:
+
+```bash
+$ sysml demo.sysml
+package Demo
+  part def Vehicle {
+    attribute speed : Real;
+  }
+SysML v2 REPL — %help for commands, Ctrl-D to exit
+sysml> 
 ```
 
 ## Error Handling
 
-Errors are written to stderr:
+Errors are written to stderr with exit code 1:
 
 ```bash
-sysml -l missing.sysml -e x
-# stderr: sysml: load missing.sysml: no such file or directory
+sysml missing.sysml
+# stderr: error loading missing.sysml: open missing.sysml: no such file or directory
 # exit code: 1
 
-sysml -q -l model.sysml -e nonexistent 2> errors.log
+sysml -e "nonexistent" model.sysml 2> errors.log
 # stderr written to errors.log
-```
-
-## Piping (Alternative to --load/--eval)
-
-You can still use stdin piping for interactive-style input:
-
-```bash
-echo "%load model.sysml" | sysml
-echo -e "%load model.sysml\n%eval x" | sysml
 ```
 
 ## Use Cases
 
-1. **Automated Testing**: Run model evaluations in CI/CD pipelines
-2. **Scripting**: Extract calculated values for other tools
-3. **Validation**: Check model properties without manual interaction
-4. **Batch Processing**: Process multiple models programmatically
-5. **Integration**: Use SysML as a calculation engine for other systems
+1. **Quick Calculations**: Use as a calculator with `-e`
+2. **Automated Testing**: Run model evaluations in CI/CD pipelines
+3. **Scripting**: Extract calculated values for other tools
+4. **Validation**: Check model properties without manual interaction
+5. **Batch Processing**: Process multiple models programmatically
+6. **Interactive Development**: Load files and explore in REPL
 
 ## Tips
 
-- Use `-q` for clean output when piping to other tools
+- Put options (`-e`, `-v`) **before** file arguments
+- Use `%help` in REPL to see all meta commands
 - Combine multiple `-e` flags to evaluate related expressions
-- Load common definitions with `-l` before custom models
+- Load common definitions before custom models
 - Check exit codes: 0 = success, 1 = error
 - Redirect stderr separately from stdout for error handling
+- Use shell pipes for REPL automation: `echo "%load file.sysml" | sysml`

--- a/examples/README.md
+++ b/examples/README.md
@@ -172,12 +172,14 @@ Demonstrates behavioral AST parsing:
 
 1. **Build the REPL:**
    ```bash
-   go build -o sysml ./cmd/sysml
+   make build
    ```
 
 2. **Load an example:**
    ```bash
-   ./sysml
+   ./bin/sysml examples/action-executor-demo.sysml
+   # OR use REPL command:
+   ./bin/sysml
    sysml> %load examples/action-executor-demo.sysml
    ```
 


### PR DESCRIPTION
- Add Makefile with version-aware builds
- Targets: build, test, clean, install, help
- Injects version info via ldflags (git describe, commit, timestamp)
- Improve CLI usage output with examples
- Clarify standard flag ordering: sysml [options] [file...]
- No behavior changes, just better developer experience