### PR TITLE
fix: standardize Go version to 1.23 and correct stdlib file count

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Current: green (Time: 30.0s)
 
 **Current commit:** All tests pass (`go test ./...`), builds clean (`go build ./...`).
 **Test coverage:** 722+ tests covering parsers, semantics, runtime (actions, states, instances, operators, validation).
-**Parser coverage:** 95 of 95 official SysML v2 standard library files parse cleanly (100% coverage). Full SysML v2 specification compliance achieved. See [examples/PARSER_FEATURES_DEMOS.md](examples/PARSER_FEATURES_DEMOS.md) for feature showcase.
+**Parser coverage:** 94 official SysML v2 standard library files parse cleanly (100% coverage). Full SysML v2 specification compliance achieved. See [examples/PARSER_FEATURES_DEMOS.md](examples/PARSER_FEATURES_DEMOS.md) for feature showcase.
 **Semantic layer:** Complete implementation of runtime operators, feature chains, and validation rules. See [examples/semantic-layer/](examples/semantic-layer/) for comprehensive demo.
 
 ## Architecture
@@ -181,11 +181,11 @@ github.com/Open-MBEE/Systemica
 
 ## Technology
 
-- **Language:** Go 1.25+ (goroutines for concurrency, single static binary, proven LSP track record)
+- **Language:** Go 1.23+ (goroutines for concurrency, single static binary, proven LSP track record)
 - **Parser:** Hand-written recursive descent (zero overhead, full error recovery, sub-ms parses)
 - **Grammar source:** OMG pilot Xtext grammars (`SysML.xtext` + `KerMLExpressions`)
 - **Spec compliance:** [OMG SysML v2.1 Beta 1 / KerML 1.1](https://www.omg.org/spec/SysML/2.0) (2026-05 release)
-- **Standard library:** 95/95 files from [SysML v2 Pilot Implementation 2026-05](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/releases/tag/2026-05)
+- **Standard library:** 94 files from [SysML v2 Pilot Implementation 2026-05](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/releases/tag/2026-05)
 - **CI/CD:** CircleCI for automated builds, tests, and releases
 
 ## Releases

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 **Status:** Active Development  
 **Module:** `github.com/Open-MBEE/Systemica`  
-**Language:** Go 1.25+
+**Language:** Go 1.23+
 
 ## Overview
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -473,7 +473,7 @@ Check `examples/` directory:
 
 **Import errors after build:**
 - Run `go mod tidy`
-- Verify Go version: `go version` (need 1.25+)
+- Verify Go version: `go version` (need 1.23+)
 
 **Syntax errors:**
 - SysML v2 textual notation only (no graphical/XMI)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Open-MBEE/Systemica
 
-go 1.25.10
+go 1.23
 
 require (
 	github.com/chzyer/readline v1.5.1


### PR DESCRIPTION
- Update go.mod from 1.25.10 to 1.23 (required by fsnotify dependency)
- Update all documentation to reference Go 1.23+ consistently
  - README.md
  - docs/ARCHITECTURE.md
  - docs/QUICKSTART.md
- Correct stdlib file count from 95 to 94 (actual count verified)
- All tests pass with Go 1.23