### PR TITLE
Fix: Sourceless accept...then Transitions Dropped During Lowering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Systemica!
 
 ### Prerequisites
 
-- Go 1.23 or later
+- Go 1.25 or later
 - Git
 - Make (recommended for build automation)
 
@@ -15,7 +15,7 @@ Thank you for your interest in contributing to Systemica!
 ```bash
 git clone https://github.com/Open-MBEE/Systemica.git
 cd Systemica
-make build  # builds bin/sysml and bin/sysml-lsp with version info
+make build  # builds bin/sysml, bin/sysml-lsp, and bin/sysml-grpc with version info
 make test   # runs all tests
 ```
 
@@ -30,9 +30,15 @@ make build
 # Build specific binary
 make build-sysml
 make build-lsp
+make build-grpc
 
 # Install to $GOPATH/bin
 make install
+
+# Python gRPC bindings
+make python-proto    # regenerate protobuf stubs
+make python-install  # install pysysml package
+make python-test     # run Python binding tests
 
 # Clean build artifacts
 make clean
@@ -65,7 +71,7 @@ go test ./internal/core/parser
 
 1. **Conformance gate:** `go test -run TestStdlibConformance ./internal/core/libs`
 2. **Golden ASTs:** `go test -run TestGolden ./internal/core/parser`
-3. **Negative tests:** `go test -run TestNegativeParsing ./internal/core/parser`
+3. **Negative tests:** `go test -run TestNegative ./internal/core/parser`
 4. **Update goldens** (after intentional changes): `go test -run TestGolden -update ./internal/core/parser`
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#parser-test-contract) for full details on the parser testing contract.
@@ -184,7 +190,7 @@ PRs must pass:
 
 ```
 github.com/Open-MBEE/Systemica
-├── cmd/                    # Binaries (sysml, sysml-lsp)
+├── cmd/                    # Binaries (sysml, sysml-lsp, sysml-grpc)
 ├── internal/core/          # Core implementation
 │   ├── source/            # Source file handling
 │   ├── lexer/             # Tokenization
@@ -194,10 +200,14 @@ github.com/Open-MBEE/Systemica
 │   ├── resolve/           # Name resolution
 │   ├── semantics/         # Type system
 │   ├── passes/            # Validation
+│   ├── lower/             # AST → execution IR (ActionGraph/StateGraph)
 │   ├── runtime/           # Execution
-│   └── model/             # Workspace
+│   ├── model/             # Workspace
+│   └── libs/              # Standard library bundling
 ├── internal/lsp/          # LSP implementation
+├── internal/grpc/         # gRPC service implementation
 ├── internal/repl/         # REPL implementation
+├── python/                # Python client bindings (pysysml)
 ├── docs/                  # Documentation
 ├── testdata/              # Test fixtures
 └── .circleci/             # CI configuration

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Current: green (Time: 30.0s)
 
 - **Language Server** — First-class IDE support (VS Code, IntelliJ, Emacs, etc.) with live diagnostics, semantic hover, go-to-definition, intelligent completion, and workspace-wide symbol search.
 - **Interactive REPL** — Exploratory modeling environment: define models incrementally, evaluate expressions on-the-fly, instantiate parts, run calculations, inspect runtime state—like IPython/Jupyter for systems engineering.
-- **Execution Runtime** — Not just a validator: instantiate parts, evaluate constraints against concrete values, execute calc/analysis cases. Action/state executor infrastructure complete (fork/join parallelism, decision guards, hierarchical states, TimeEvent/ChangeEvent). See [SPEC_COMPLIANCE.md](docs/SPEC_COMPLIANCE.md) for measured behavioral coverage.
+- **Execution Runtime** — Not just a validator: instantiate parts, evaluate constraints against concrete values, execute calc/analysis cases. Action/state executor infrastructure complete (activity fork/join parallelism, decision guards, hierarchical/orthogonal states, choice/junction pseudostates, TimeEvent/ChangeEvent). See [SPEC_COMPLIANCE.md](docs/SPEC_COMPLIANCE.md) for measured behavioral coverage.
 - **Modern Toolchain** — Dependency management (local + remote git), incremental compilation, bundled standard library, persistent semantic caches—`cargo`/`go mod` ergonomics for systems modeling.
 
 ## Goals
@@ -117,18 +117,18 @@ Current: green (Time: 30.0s)
 | Expression evaluator & instance model (runtime Tiers 1-3) | ✅ Complete |
 | Runtime operators (equality, logical, negation) | ✅ Complete |
 | Workspace/reindex/file watching | ✅ Complete |
-| Behavioral parser (unified grammar with graceful fallback) | ✅ Complete (16 golden ASTs, 16 negative tests) |
-| Calc invocation, constraint & requirement evaluation | ✅ Complete (conformance gate: 9/9 passing) |
-| Action execution engine (Tier 5) | ✅ Complete (26 unit tests, 20/20 conformance passing) |
-| State machine runtime (Tier 5) | ✅ Complete (15 unit tests, 20/20 conformance passing) |
+| Behavioral parser (unified grammar with graceful fallback) | ✅ Complete (16 golden ASTs, 15 negative tests) |
+| Calc invocation, constraint & requirement evaluation | ✅ Complete (conformance gate: 12/12 passing) |
+| Action execution engine (Tier 5) | ✅ Complete (5 conformance cases passing) |
+| State machine runtime (Tier 5) | ✅ Complete (9 conformance cases passing) |
 | REPL debugging commands | ✅ Complete |
 | Standard library bundling | ✅ Complete |
 | LSP server implementation | ✅ Complete |
 
 **Current commit:** All tests pass (`go test ./...`), builds clean (`go build ./...`).
-**Test coverage:** 890+ tests covering parsers, semantics, runtime (actions, states, instances, operators, validation). Behavioral robustness: 16 golden ASTs, 16 negatives, 20 conformance cases, 6 robustness tests.
+**Test coverage:** 890+ tests covering parsers, semantics, runtime (actions, states, instances, operators, validation). Behavioral robustness: 16 golden ASTs, 15 negatives, 26 conformance cases, 7 robustness tests.
 **Parser coverage:** 94/94 official SysML v2 standard library files parse cleanly. Conformance verified by [stdlib_conformance_test.go](internal/core/libs/stdlib_conformance_test.go). Grammar reference: [OMG Xtext grammar](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/tree/master/org.omg.kerml.xtext/src/org/omg/kerml/xtext).
-**Behavioral execution:** Calc/constraint/requirement fully functional (9/9 tests). Action/state executors complete with nested invocation, control flow keywords, send statement (18/18 conformance tests passing). See [SPEC_COMPLIANCE.md](docs/SPEC_COMPLIANCE.md) for measured compliance (~98% faithful implementation).
+**Behavioral execution:** Calc/constraint/requirement fully functional (12/12 tests). Action/state executors complete with nested invocation, control flow keywords, send statement (26/26 conformance tests passing). See [SPEC_COMPLIANCE.md](docs/SPEC_COMPLIANCE.md) for measured compliance (~98% faithful implementation).
 **Training examples:** 63/100 files clean. Download from [OMG training directory](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/tree/master/sysml/src/training). See [docs/TRAINING_EXAMPLES.md](docs/TRAINING_EXAMPLES.md) for analysis.
 **Semantic layer:** Complete implementation of runtime operators, feature chains, and validation rules. See [examples/semantic-layer/](examples/semantic-layer/) for comprehensive demo.
 
@@ -162,6 +162,7 @@ Current: green (Time: 30.0s)
 github.com/Open-MBEE/Systemica
 ├── cmd/
 │   ├── sysml-lsp/          # LSP server binary
+│   ├── sysml-grpc/         # gRPC server binary (Python bindings)
 │   └── sysml/              # Interactive REPL binary
 ├── internal/core/
 │   ├── source/             # Source files, spans, line indexing
@@ -172,18 +173,21 @@ github.com/Open-MBEE/Systemica
 │   ├── resolve/            # Name resolution (lazy, memoized)
 │   ├── semantics/          # Type system, conformance, multiplicity
 │   ├── passes/             # Validation passes (syntax → constraints)
+│   ├── lower/              # AST → execution IR (ActionGraph/StateGraph)
 │   ├── runtime/            # Execution engine (eval, instances, builtins)
 │   ├── model/              # Workspace, document management
 │   └── libs/               # Standard library bundling & caching
 ├── internal/lsp/           # LSP protocol implementation
+├── internal/grpc/          # gRPC service implementation
 ├── internal/repl/          # REPL loop implementation
+├── python/                 # Python client bindings (pysysml)
 ├── docs/                   # Design specs, architecture docs
 └── testdata/               # Test fixtures (.sysml, .kerml)
 ```
 
 ## Technology
 
-- **Language:** Go 1.23+ (goroutines for concurrency, single static binary, proven LSP track record)
+- **Language:** Go 1.25+ (goroutines for concurrency, single static binary, proven LSP track record)
 - **Parser:** Hand-written recursive descent (zero overhead, full error recovery, sub-ms parses)
 - **Grammar source:** OMG pilot Xtext grammars (`SysML.xtext` + `KerMLExpressions`)
 - **Spec compliance:** [OMG SysML v2.1 Beta 1 / KerML 1.1](https://www.omg.org/spec/SysML/2.0) (2026-05 release)
@@ -268,7 +272,7 @@ Apache 2.0
 
 ## Contributing
 
-Project currently in active development. Contribution guidelines forthcoming.
+Project currently in active development. See [CONTRIBUTING.md](CONTRIBUTING.md) for build, test, and contribution guidelines.
 
 ## Contact
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,11 +19,13 @@ github.com/Open-MBEE/Systemica
 │   ├── resolve/            # Name resolution
 │   ├── semantics/          # Type system and semantic queries
 │   ├── passes/             # Validation passes
+│   ├── lower/              # AST → execution IR (ActionGraph/StateGraph)
 │   ├── runtime/            # Execution runtime
 │   ├── model/              # Workspace and document management
 │   ├── libs/               # Standard library handling
 │   └── deps/               # Dependency resolution
 ├── internal/lsp/           # Language Server Protocol
+├── internal/grpc/          # gRPC service implementation
 └── internal/repl/          # Interactive REPL
 ```
 
@@ -202,7 +204,7 @@ Symbol tables and scope trees.
 **Usage:**
 ```go
 idx := symbols.NewIndex()
-idx.Register("example.sysml", root) // root is *ast.RootNamespace
+idx.AddDocument("example.sysml", root) // root is *ast.RootNamespace
 scope := idx.DocumentRoot("example.sysml")
 sym, ok := scope.LookupLocal("Wheel")
 ```
@@ -287,7 +289,7 @@ Higher tiers skip if lower tier fails.
 
 - **`Pass`** — Validation pass interface
   - `Level() PassLevel` — Which tier
-  - `Run(ctx Context, docName string, root *ast.RootNamespace) []Diagnostic`
+  - `Run(ctx *Context, name string, root *ast.RootNamespace) []Diagnostic`
 
 - **`Context`** — Provides access to resolver and model
   - `Resolver() *resolve.Resolver`
@@ -300,8 +302,8 @@ Higher tiers skip if lower tier fails.
 
 **Usage:**
 ```go
-reg := passes.DefaultRegistry()
-diagnostics := passes.Analyze(ctx, reg, "example.sysml", root)
+// Analyze runs the default pass registry internally.
+diagnostics := passes.Analyze("example.sysml", root, parseDiags, idx)
 ```
 
 ---
@@ -500,14 +502,13 @@ Language Server Protocol implementation.
 
 **Current Capabilities:**
 - Document synchronization (open/change/close)
-- Diagnostics (syntax errors)
-
-**Planned:**
+- Diagnostics (syntax + semantic errors)
 - Hover (type info)
 - Go to definition
-- Completion
-- Workspace symbols
 - References
+- Document symbols
+- Workspace symbols
+- Completion
 
 **Usage:**
 ```go
@@ -584,7 +585,7 @@ import (
 )
 
 idx := symbols.NewIndex()
-idx.Register("example.sysml", root)
+idx.AddDocument("example.sysml", root)
 scope := idx.DocumentRoot("example.sysml")
 sym, ok := scope.LookupLocal("Wheel")
 ```
@@ -619,9 +620,8 @@ import (
     "github.com/Open-MBEE/Systemica/internal/core/passes"
 )
 
-ctx := passes.NewContext(res, model)
-reg := passes.DefaultRegistry()
-diagnostics := passes.Analyze(ctx, reg, "example.sysml", root)
+// Analyze wires up the default pass registry and context internally.
+diagnostics := passes.Analyze("example.sysml", root, parseDiags, idx)
 ```
 
 ### Execute Runtime
@@ -631,10 +631,10 @@ import (
     "github.com/Open-MBEE/Systemica/internal/core/runtime"
 )
 
-rtCtx := runtime.New(model)
+rtCtx := runtime.NewContext(model, resolver, 100000)
 inst, _ := rtCtx.Instantiate(wheelSym)
-diameterVal, _ := rtCtx.GetSlot(inst, diameterFeatureSym)
-fmt.Println(diameterVal) // Value{Kind: ValConst, Real: 16.0}
+diameterSlot, _ := inst.GetSlot(rtCtx, "diameter")
+fmt.Println(diameterSlot.Value) // Value{Kind: ValConst, Real: 16.0}
 ```
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,6 +50,7 @@ A complete, production-grade SysML v2 implementation delivering the integrated t
 github.com/Open-MBEE/Systemica
 ├── cmd/
 │   ├── sysml-lsp/          # LSP server binary
+│   ├── sysml-grpc/         # gRPC server binary
 │   └── sysml/              # Interactive REPL binary
 ├── internal/core/
 │   ├── source/             # Source files, spans, line indexing
@@ -60,12 +61,16 @@ github.com/Open-MBEE/Systemica
 │   ├── resolve/            # Name resolution (lazy, memoized)
 │   ├── semantics/          # Type system, conformance, multiplicity
 │   ├── passes/             # Validation passes (syntax → constraints)
+│   ├── lower/              # AST → execution IR (ActionGraph/StateGraph)
 │   ├── runtime/            # Execution engine (eval, instances, builtins)
 │   ├── model/              # Workspace, document management
 │   ├── libs/               # Standard library bundling & caching
 │   └── deps/               # Dependency resolution
 ├── internal/lsp/           # LSP protocol implementation
 ├── internal/repl/          # REPL loop implementation
+├── internal/grpc/          # gRPC service implementation
+├── python/                 # Python client bindings (pysysml)
+├── api/proto/              # Protobuf service definitions
 ├── testdata/               # Test fixtures (.sysml, .kerml)
 ├── examples/               # Example models and demos
 └── docs/                   # Documentation
@@ -201,7 +206,7 @@ Parse + model all behavioral bodies with unified fallback grammar:
 ### Tier 5 — Behavioral Interpreter ✅ Complete
 
 **Package:** `internal/core/runtime`  
-**Status:** Complete with 890+ tests. Conformance gate: 20/20 cases passing (calc/constraint/requirement/action/state all functional).  
+**Status:** Complete with 890+ tests. Conformance gate: 26/26 cases passing (calc/constraint/requirement/action/state all functional).  
 **Spec Alignment:** Token-flow semantics align with UML 2.5.1 Activity diagrams; state machine execution follows UML 2.5.1 StateMachine run-to-completion semantics. See [SPEC_COMPLIANCE.md](SPEC_COMPLIANCE.md) for detailed compliance mapping (~98% faithful implementation).
 
 **Architecture:**
@@ -218,14 +223,17 @@ Parse + model all behavioral bodies with unified fallback grammar:
 
 2. **StateExecutor** — Event-driven state machine execution
    - Initial/final state keywords (initial/final)
-   - Entry/exit/do behaviors
+   - Entry/exit/do behaviors (⚠️ `do` runs synchronously on entry, not concurrently)
    - TimeEvent scheduling with priority queue
    - ChangeEvent condition polling
    - Guard evaluation for transitions
    - Transition effect actions
    - Hierarchical states with LCA-based entry/exit propagation
+   - Orthogonal regions with multi-region event broadcasting
+   - Choice + Junction pseudostates
    - Golden trace recording for transitions/entry/exit
    - APIs: `ProcessNextEvent()`, `CurrentState()`, `EventQueue()`, `StateData()`, `SetTrace()`
+   - **Known limitations:** Fork/Join/Entry/Exit/History pseudostates return "unsupported pseudostate kind" (`state_executor.go:552`); no deferred events; CallEvent matches any call (`matchesEvent:437` TODO); nested action invocation in behaviors not implemented (`executeAction:862`)
 
 3. **Context Integration** — Public runtime APIs
    - `InvokeCalc(symbol, args)` — Invoke calculation with arguments, return result
@@ -237,20 +245,21 @@ Parse + model all behavioral bodies with unified fallback grammar:
    - `CreateStateExecutor(symbol)` — Create executor for debugging
 
 **Implementation:**
-- `context.go` (424 lines) — Public Execute/Invoke/Evaluate APIs, step budget enforcement
-- `action_executor.go` (780+ lines) — Token-flow engine with nested actions, send statement
-- `state_executor.go` (590+ lines) — Event-driven state machine with do behaviors
+- `context.go` (460 lines) — Public Execute/Invoke/Evaluate APIs, step budget enforcement
+- `action_executor.go` (729 lines) — Token-flow engine with nested actions, send statement
+- `state_executor.go` (1149 lines) — Event-driven state machine with do behaviors
 - `executor_common.go` — Token, Event, EventQueue, ExecutionState
-- `trace.go` (168 lines) — Deterministic execution trace recorder
+- `trace.go` (154 lines) — Deterministic execution trace recorder
 - `eval.go` — Expression evaluation (binary/unary operators, literals, feature references, qualified names, type coercion)
+- Lowering to execution IR lives in `internal/core/lower/` (`ToActionGraph`, `ToStateGraph`)
 
 **Testing:**
-- **Golden ASTs**: 19 behavioral fixtures - `internal/core/parser/testdata/parse/`
-- **Negative tests**: 16 cases - `internal/core/parser/negative_test.go`
-- **Unit tests**: 41 tests (26 action, 15 state) - `action_executor_test.go`, `state_executor_test.go`
-- **Conformance gate**: 20 cases (all passing: calc×4, constraint×3, requirement×5, action×4, state×2) - `conformance_test.go`
+- **Golden ASTs**: 16 behavioral fixtures - `internal/core/parser/testdata/parse/`
+- **Negative tests**: 15 cases - `internal/core/parser/negative_test.go`
+- **Unit tests**: 41 tests (action, state) - `action_executor_test.go`, `state_executor_test.go`
+- **Conformance gate**: 26 cases (all passing: calc×4, constraint×3, requirement×5, action×5, state×9) - `conformance_test.go`
 - **Golden traces**: Infrastructure ready (no .trace.golden files yet) - `trace_test.go`
-- **Robustness**: 6 failure-mode tests (deadlock, unbound params, missing features, dangling transitions, step budget) - `robustness_test.go`
+- **Robustness**: 7 failure-mode tests (deadlock, unbound params, missing features, dangling transitions, sourceless accept, step budget) - `robustness_test.go`
 - **Coverage**: All behavioral types fully functional. Action: 14/14 features ✅. State: 13/13 features ✅. Calc: 8/8 ✅. Constraint: 5/5 ✅. Requirement: 5/5 ✅. Evaluation: 7/7 ✅.
 
 **Measured Compliance:** See [SPEC_COMPLIANCE.md](SPEC_COMPLIANCE.md) for semantic rule → implementation → test case mapping with status (✅ faithful / ⚠️ approximate / ❌ not yet implemented).
@@ -477,8 +486,8 @@ go test -v -run TestStdlibConformance ./internal/core/libs
 #### 2. Golden AST Snapshots
 - **Purpose:** Verify AST structure matches expected output
 - **Location:** `internal/core/parser/golden_test.go`
-- **Fixtures:** `testdata/parse/*.sysml` (9 representative files)
-- **Goldens:** `testdata/parse/*.ast.txt` (AST dumps)
+- **Fixtures:** `testdata/parse/*.sysml` (16 representative files)
+- **Goldens:** `testdata/parse/*.golden` (AST dumps)
 - **Acceptance:** Parse output matches golden file
 - **Update flag:** `go test -run TestGolden -update` (regenerate goldens after intentional changes)
 
@@ -539,15 +548,15 @@ New behavioral features (actions, states, calc, constraints, requirements) requi
 - **Location:** `internal/core/runtime/conformance_test.go`
 - **Test:** `TestExecutionConformance` runs `.sysml` + `.expected.json` pairs
 - **Schema:** `internal/core/runtime/testdata/conformance/README.md` (outcome format for each behavioral type)
-- **Allowlist:** `known_failures.txt` (currently: action_output, state_simple - blocked by initial node parsing)
+- **Allowlist:** `known_failures.txt` (currently empty — all cases pass)
 - **Acceptance:** Expected outputs/satisfaction match actual execution results
 
-**Coverage (5 cases):**
-- Calc: parameter binding, return values (1 passing: `calc_simple_add`)
-- Constraint: assert satisfaction (1 passing: `constraint_literal`)
-- Requirement: require satisfaction (1 passing: `requirement_literal`)
-- Action: token flow, outputs (1 known failure: `action_output` - no initial node)
-- State: transitions, final state (1 known failure: `state_simple` - no initial state)
+**Coverage (26 cases):**
+- Calc: parameter binding, return values, unary operators, type coercion, qualified names (×4)
+- Constraint: assert/assume satisfaction, negation (×3)
+- Requirement: require/subject/actor/assume satisfaction, nested (×5)
+- Action: token flow, outputs, nested invocation, send/accept, port communication (×5)
+- State: simple, do behavior, transition effect, choice/junction pseudostates, orthogonal regions, signal discrimination/unmatched, accept...then (×9)
 
 **Usage:**
 ```bash
@@ -570,13 +579,14 @@ go test -v -run TestExecutionConformance ./internal/core/runtime
 #### 4. Runtime Robustness Tests
 - **Purpose:** Verify malformed/pathological behaviors fail gracefully (typed errors, no panics/hangs)
 - **Location:** `internal/core/runtime/robustness_test.go`
-- **Test:** `TestRuntimeRobustness` with 6 failure modes
+- **Test:** `TestRuntimeRobustness` with 7 failure modes
 - **Acceptance:** All return typed errors, never panic, timeout guard (60s) prevents hangs
 
 **Failure modes:**
 - Deadlocked action (join starvation)
 - Decision with no satisfied guard
 - State machine with dangling transition
+- Sourceless accept...then at top level
 - Calc with unbound parameter
 - Constraint referencing missing feature
 - Step budget exceeded
@@ -598,7 +608,7 @@ Every behavioral feature must have:
 - Test case(s) exercising the feature
 - Status: ✅ Faithful / ⚠️ Approximate / ❌ Not Yet Implemented / 🚧 Known Failure
 
-**Current coverage:** ~70% faithful implementation. Calc/constraint/requirement fully functional. Action/state executor infrastructure complete (fork/join/decision, TimeEvent/ChangeEvent, guards, hierarchy all tested), conformance cases blocked by initial node/state parsing.
+**Current coverage:** ~98% faithful implementation. Calc/constraint/requirement fully functional. Action/state executor infrastructure complete (fork/join/decision, TimeEvent/ChangeEvent, guards, hierarchy, orthogonal regions all tested); all 26 conformance cases pass. Advanced state-machine features remain unimplemented (fork/join/history pseudostates, deferred events, concurrent `do`) — see SPEC_COMPLIANCE.md.
 
 ---
 
@@ -608,8 +618,6 @@ Every behavioral feature must have:
 - **Test fixtures:** `testdata/*.sysml`, `testdata/*.kerml`
 - **Golden files:** Expected parse/resolve/diagnostic outputs
 - **Verification:** `go test ./...` (all tests pass), `go build ./...` (clean build)
-
-### Contributing New Grammar Features
 
 ### Contributing New Grammar Features
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -38,11 +38,12 @@ Download `sysml-windows-amd64.zip` from [releases](https://github.com/Open-MBEE/
 **Available binaries:**
 - `sysml` — Interactive REPL
 - `sysml-lsp` — Language Server Protocol server
+- `sysml-grpc` — gRPC service (backs the Python bindings)
 
 ### Option 2: Build from Source
 
 **Prerequisites:**
-- Go 1.23 or later
+- Go 1.25 or later
 - Git
 - Make (optional but recommended)
 
@@ -50,7 +51,7 @@ Download `sysml-windows-amd64.zip` from [releases](https://github.com/Open-MBEE/
 ```bash
 git clone https://github.com/Open-MBEE/Systemica.git
 cd Systemica
-make build       # builds bin/sysml and bin/sysml-lsp
+make build       # builds bin/sysml, bin/sysml-lsp, and bin/sysml-grpc
 # OR
 go build -o sysml ./cmd/sysml
 go build -o sysml-lsp ./cmd/sysml-lsp
@@ -60,7 +61,7 @@ go build -o sysml-lsp ./cmd/sysml-lsp
 ```bash
 make install     # installs to $GOPATH/bin
 # OR
-sudo mv bin/sysml bin/sysml-lsp /usr/local/bin/
+sudo mv bin/sysml bin/sysml-lsp bin/sysml-grpc /usr/local/bin/
 ```
 
 ---
@@ -387,7 +388,7 @@ sysml> %advance
 - `%advance` — Process next event
 - `%stop` — Stop debugging
 
-**See [examples/action-demo.sysml](../examples/action-demo.sysml) and [examples/state-demo.sysml](../examples/state-demo.sysml) for complete workflows.**
+**See [examples/action-executor-demo.sysml](../examples/action-executor-demo.sysml) and [examples/state-machine-demo.sysml](../examples/state-machine-demo.sysml) for complete workflows.**
 
 ---
 
@@ -451,8 +452,9 @@ echo 'part Wheel { attribute diameter = 16.0; }' > test.sysml
 ## Examples
 
 Check `examples/` directory:
-- `runtime_repl_demo.md` — Full runtime walkthrough
-- `behavior_demo.sysml` — Action body examples
+- `repl-behavioral-demo.sysml` — REPL behavioral walkthrough
+- `ACTION-EXECUTOR-DEMO.md` — Action executor walkthrough
+- `CLI_USAGE.md` — CLI usage reference
 
 ---
 
@@ -469,11 +471,11 @@ Check `examples/` directory:
 
 **REPL doesn't show prompt:**
 - Check terminal supports readline (most Unix shells do)
-- History stored in `/tmp/sysml.history`
+- History stored in `$TMPDIR/sysml-repl.history`
 
 **Import errors after build:**
 - Run `go mod tidy`
-- Verify Go version: `go version` (need 1.23+)
+- Verify Go version: `go version` (need 1.25+)
 
 **Syntax errors:**
 - SysML v2 textual notation only (no graphical/XMI)

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,6 @@
 ## Quick Links
 
 - **Source:** [github.com/Open-MBEE/Systemica](https://github.com/Open-MBEE/Systemica)
-- **License:** MIT
+- **License:** Apache 2.0
 - **Go Module:** `github.com/Open-MBEE/Systemica`
-- **Go Version:** 1.23+
+- **Go Version:** 1.25+

--- a/docs/SPEC_COMPLIANCE.md
+++ b/docs/SPEC_COMPLIANCE.md
@@ -181,6 +181,7 @@ Each row documents one behavioral semantic feature:
 | Transition guard evaluation | `state_executor.go:225` scheduleTransitionEvents | `state_choice_pseudostate.sysml` | ✅ Faithful |
 | Transition effect actions | `state_executor.go:586` fireTransition | `state_transition_effect.sysml` | ✅ Faithful |
 | AcceptEvent triggers (when signal) | `state_executor.go:292` matchesEvent | `state_signal_discriminate.sysml` | ✅ Faithful |
+| Sourceless transitions (`accept...then`) | `state_graph.go:487` collectTransitions Usage case, `:302` resolve container | `accept_then_transition.sysml` | ✅ Faithful (nested form only; flat form errors intentionally) |
 | ChangeEvent triggers (when expr) | `state_executor.go:292` matchesEvent | `state_executor_test.go:TestStateChangeEvent` | ✅ Faithful |
 | TimeEvent triggers (after/at) | `state_executor.go:292` matchesEvent | `state_executor_test.go:TestStateTimeEvent` | ✅ Faithful |
 | Signal discrimination | `state_executor.go:308` matchesEvent signal name | `state_signal_discriminate.sysml` | ✅ Faithful |

--- a/docs/SPEC_COMPLIANCE.md
+++ b/docs/SPEC_COMPLIANCE.md
@@ -50,14 +50,15 @@
 - Token-flow tracing (infrastructure ready)
 - Step budget enforcement
 
-**State Machines (22/22 features):**
+**State Machines (core: faithful; advanced: partial):**
 - Initial/final state identification
 - State entry/exit actions
-- State do behavior (simplified immediate execution)
+- State do behavior (⚠️ simplified: immediate, not concurrent)
 - Transition firing
 - Transition guard evaluation
 - Transition effect actions
 - AcceptEvent triggers (when signal)
+- Sourceless transitions (`accept...then`, nested form)
 - ChangeEvent triggers (when expression)
 - TimeEvent triggers (after duration)
 - Signal discrimination (name matching)
@@ -69,10 +70,10 @@
 - Junction pseudostates (static branching)
 - Run-to-completion semantics
 - Event queue management
-- Dangling transition detection
+- Dangling transition detection (⚠️ lenient)
 - State visits tracking
 - Multi-region event broadcasting
-- Control flow node registration (initial/final/first/done)
+- ❌ Not implemented: Fork/Join/Entry/Exit/History pseudostates, deferred events, concurrent `do`, nested action invocation in behaviors, CallEvent operation-name matching
 
 **Expression Evaluation (7/7 features):**
 - Binary operators (+, -, *, /, <, >, ==, and, or)
@@ -90,8 +91,8 @@
 - Control flow node scope registration
 
 **Test Coverage:**
-- 23 conformance cases (all passing: calc×4, constraint×3, requirement×5, action×5, state×6)
-- 6 robustness tests (deadlock, guards, budgets)
+- 26 conformance cases (all passing: calc×4, constraint×3, requirement×5, action×5, state×9)
+- 7 robustness tests (deadlock, guards, budgets, sourceless accept)
 - 41 unit tests
 - 19 golden AST fixtures (including pseudostate parsing tests)
 - 16 negative parser tests
@@ -118,15 +119,15 @@ Each row documents one behavioral semantic feature:
 
 | Semantic Rule | Implementation | Test Case | Status |
 |--------------|----------------|-----------|--------|
-| Calc invocation with typed parameters | `context.go:228` `InvokeCalc` | `calc_simple_add.sysml` | ✅ Faithful |
-| Return expression evaluation | `eval.go` + `context.go:228` | `calc_simple_add.sysml` | ✅ Faithful |
-| Parameter binding (positional) | `context.go:228` (args slice) | `calc_simple_add.sysml` | ✅ Faithful |
-| Parameter binding (named arguments) | `context.go:228` | `requirement_invocation_test.go` | ✅ Faithful |
-| Unbound parameter detection | `context.go:228` | `robustness_test.go:testCalcUnboundParameter` | ✅ Faithful |
+| Calc invocation with typed parameters | `context.go:254` `InvokeCalc` | `calc_simple_add.sysml` | ✅ Faithful |
+| Return expression evaluation | `eval.go` + `context.go:254` | `calc_simple_add.sysml` | ✅ Faithful |
+| Parameter binding (positional) | `context.go:254` (args slice) | `calc_simple_add.sysml` | ✅ Faithful |
+| Parameter binding (named arguments) | `context.go:254` | `requirement_invocation_test.go` | ✅ Faithful |
+| Unbound parameter detection | `context.go:254` | `robustness_test.go:testCalcUnboundParameter` | ✅ Faithful |
 | Control flow (if/else) in calc | `eval.go` expression evaluation | `robustness_test.go:testDecisionNoSatisfiedGuard` | ✅ Faithful |
-| Missing return expression | `context.go:228` error path | `robustness_test.go:testDecisionNoSatisfiedGuard` | ✅ Faithful |
-| Unary operators (not, -) | `eval.go:485` evalNeg | `calc_unary_operators.sysml` | ✅ Faithful |
-| Type coercion (Integer→Real) | `eval.go:346` toReal | `calc_type_coercion.sysml` | ✅ Faithful |
+| Missing return expression | `context.go:254` error path | `robustness_test.go:testDecisionNoSatisfiedGuard` | ✅ Faithful |
+| Unary operators (not, -) | `eval.go:483` evalNeg | `calc_unary_operators.sysml` | ✅ Faithful |
+| Type coercion (Integer→Real) | `eval.go:344` toReal | `calc_type_coercion.sysml` | ✅ Faithful |
 | Qualified names (A::B::C) | `eval.go` + `resolve/` | `calc_qualified_names.sysml` | ✅ Faithful |
 
 ### Constraint
@@ -137,75 +138,78 @@ Each row documents one behavioral semantic feature:
 | Assume evaluation (trusted precondition) | `context.go:81` (same path) | `constraint_assume.sysml` | ✅ Faithful |
 | Bare expression as invariant | `context.go:81` | `constraint_literal.sysml` | ✅ Faithful |
 | Unresolved feature reference | `resolve` package + `eval.go` | `robustness_test.go:testConstraintMissingFeature` | ✅ Faithful |
-| Negated constraint (assert not) | `eval.go:485` evalNeg | `constraint_negation.sysml` | ✅ Faithful |
+| Negated constraint (assert not) | `eval.go:483` evalNeg | `constraint_negation.sysml` | ✅ Faithful |
 
 ### Requirement
 
 | Semantic Rule | Implementation | Test Case | Status |
 |--------------|----------------|-----------|--------|
-| Require expression evaluation | `context.go:129` `EvaluateRequirement` | `requirement_literal.sysml` | ✅ Faithful |
-| Subject binding evaluation | `context.go:168-199` (Pass 1) | `requirement_subject.sysml` | ✅ Faithful |
-| Actor binding evaluation | `context.go:168-199` (Pass 1) | `requirement_actor.sysml` | ✅ Faithful |
-| Assume expression evaluation | `context.go:211-217` (Pass 2, doesn't fail) | `requirement_assume.sysml` | ✅ Faithful |
-| Nested requirements | `context.go:201-242` (recursive) | `requirement_nested.sysml` | ✅ Faithful |
+| Require expression evaluation | `context.go:148` `EvaluateRequirement` | `requirement_literal.sysml` | ✅ Faithful |
+| Subject binding evaluation | `context.go:148` `EvaluateRequirement` (Pass 1) | `requirement_subject.sysml` | ✅ Faithful |
+| Actor binding evaluation | `context.go:148` `EvaluateRequirement` (Pass 1) | `requirement_actor.sysml` | ✅ Faithful |
+| Assume expression evaluation | `context.go:148` `EvaluateRequirement` (Pass 2, doesn't fail) | `requirement_assume.sysml` | ✅ Faithful |
+| Nested requirements | `context.go:148` `EvaluateRequirement` (recursive) | `requirement_nested.sysml` | ✅ Faithful |
 
 ### Action (UML 2.5.1 §16 Activities)
 
 | Semantic Rule | Implementation | Test Case | Status |
 |--------------|----------------|-----------|--------|
-| Initial node token placement | `action_executor.go:327` initialize | `action_control_flow.sysml` | ✅ Faithful |
-| Final node termination | `action_executor.go:652` stepFinalNode | `action_control_flow.sysml` | ✅ Faithful |
-| Fork node (1→N parallelism) | `action_executor.go:602` stepForkNode | `action_control_flow.sysml` | ✅ Faithful |
-| Join node (N→1 synchronization) | `action_executor.go:628` stepJoinNode | `action_control_flow.sysml` | ✅ Faithful |
-| Merge node (N→1 non-blocking) | `action_executor.go:565` stepMergeNode | `action_control_flow.sysml` | ✅ Faithful |
-| Decision node (guarded branching) | `action_executor.go:544` stepDecisionNode | `action_control_flow.sysml` | ✅ Faithful |
-| Action execution nodes | `action_executor.go:407` stepToken | `action_control_flow.sysml` | ✅ Faithful |
-| Nested action invocation | `action_executor.go:717` stepNestedAction | `action_nested_invocation.sysml` | ✅ Faithful |
-| Send statement (message passing) | `action_executor.go:735` stepNestedAction | `action_send_accept.sysml` | ✅ Faithful |
-| Accept action (message consumption) | `action_executor.go:757` accept detection | `action_accept_message.sysml` | ✅ Faithful |
-| Object flow (pin-to-pin data) | `action_executor.go:435` stepObjectFlow | `action_executor_test.go:TestActionObjectFlow` | ✅ Faithful |
-| Succession edges | `action_executor.go:269` extractGraph | `action_control_flow.sysml` | ✅ Faithful |
-| Deadlock detection | `action_executor.go:359` Step | `action_executor_test.go:TestActionExecutor_Deadlock_JoinStarvation` | ✅ Faithful |
-| Step budget enforcement | `context.go:253` incrementStep | `robustness_test.go:testStepBudgetExceeded` | ✅ Faithful |
+| Initial node token placement | `action_executor.go:210` initialize | `action_control_flow.sysml` | ✅ Faithful |
+| Final node termination | `action_executor.go:292` stepFinalNode | `action_control_flow.sysml` | ✅ Faithful |
+| Fork node (1→N parallelism) | `action_executor.go:312` stepForkNode | `action_control_flow.sysml` | ✅ Faithful |
+| Join node (N→1 synchronization) | `action_executor.go:342` stepJoinNode | `action_control_flow.sysml` | ✅ Faithful |
+| Merge node (N→1 non-blocking) | `action_executor.go:422` stepMergeNode | `action_control_flow.sysml` | ✅ Faithful |
+| Decision node (guarded branching) | `action_executor.go:452` stepDecisionNode | `action_control_flow.sysml` | ✅ Faithful |
+| Action execution nodes | `action_executor.go:528` stepActionExecutionNode | `action_control_flow.sysml` | ✅ Faithful |
+| Nested action invocation | `action_executor.go:574` stepNestedAction | `action_nested_invocation.sysml` | ✅ Faithful |
+| Send statement (message passing) | `action_executor.go:574` stepNestedAction | `action_send_accept.sysml` | ✅ Faithful |
+| Accept action (message consumption) | `action_executor.go:574` stepNestedAction | `action_accept_message.sysml` | ✅ Faithful |
+| Object flow (pin-to-pin data) | `action_executor.go:673` applyDataFlows | `action_output.sysml` | ✅ Faithful |
+| Succession edges | `lower/action_graph.go:ToActionGraph` | `action_control_flow.sysml` | ✅ Faithful |
+| Deadlock detection | `action_executor.go:72` Step | `action_executor_test.go:TestActionExecutor_Deadlock_JoinStarvation` | ✅ Faithful |
+| Step budget enforcement | `context.go:53` incrementStep | `robustness_test.go:testStepBudgetExceeded` | ✅ Faithful |
 
 ### State Machine (UML 2.5.1 §14 StateMachines)
 
 | Semantic Rule | Implementation | Test Case | Status |
 |--------------|----------------|-----------|--------|
-| Initial state identification | `state_executor.go:71-109` extractGraph | `state_simple.sysml` | ✅ Faithful |
-| Final state termination | `state_executor.go:184` ProcessNextEvent | `state_simple.sysml` | ✅ Faithful |
-| State entry actions | `state_executor.go:731` enterState | `state_full.sysml` | ✅ Faithful |
-| State exit actions | `state_executor.go:806` exitState | `state_full.sysml` | ✅ Faithful |
-| State do behavior (immediate) | `state_executor.go:750` enterState | `state_do_behavior.sysml` | ✅ Faithful |
-| Transition firing | `state_executor.go:561` fireTransition | `state_full.sysml` | ✅ Faithful |
-| Transition guard evaluation | `state_executor.go:225` scheduleTransitionEvents | `state_choice_pseudostate.sysml` | ✅ Faithful |
-| Transition effect actions | `state_executor.go:586` fireTransition | `state_transition_effect.sysml` | ✅ Faithful |
-| AcceptEvent triggers (when signal) | `state_executor.go:292` matchesEvent | `state_signal_discriminate.sysml` | ✅ Faithful |
-| Sourceless transitions (`accept...then`) | `state_graph.go:487` collectTransitions Usage case, `:302` resolve container | `accept_then_transition.sysml` | ✅ Faithful (nested form only; flat form errors intentionally) |
-| ChangeEvent triggers (when expr) | `state_executor.go:292` matchesEvent | `state_executor_test.go:TestStateChangeEvent` | ✅ Faithful |
-| TimeEvent triggers (after/at) | `state_executor.go:292` matchesEvent | `state_executor_test.go:TestStateTimeEvent` | ✅ Faithful |
-| Signal discrimination | `state_executor.go:308` matchesEvent signal name | `state_signal_discriminate.sysml` | ✅ Faithful |
-| Unmatched signal dropped | `state_executor.go:292` matchesEvent | `state_signal_unmatched.sysml` | ✅ Faithful |
-| Hierarchical substates | `state_executor.go:121` findInitialState | `state_full.sysml` | ✅ Faithful |
-| Orthogonal regions | `state_executor.go:194` scheduleTransitionsForState | `state_orthogonal_regions.sysml` | ✅ Faithful |
-| Choice pseudostates | `state_executor.go:395` evaluateChoicePseudostate | `state_choice_pseudostate.sysml` | ✅ Faithful |
-| Junction pseudostates | `state_executor.go:420` evaluateJunctionPseudostate | `state_junction_pseudostate.sysml` | ✅ Faithful |
-| Run-to-completion semantics | `state_executor.go:276` ProcessNextEvent | `state_executor_test.go:TestStateRunToCompletion` | ✅ Faithful |
-| Event queue management | `state_executor.go:50` eventQueue | `state_executor_test.go` | ✅ Faithful |
-| Dangling transition detection | resolve phase | `robustness_test.go:testStateDanglingTransition` | ✅ Faithful |
-| Completion transitions | `state_executor.go:222` scheduleTransitionEvents nil trigger | `state_simple.sysml` | ✅ Faithful |
+| Initial state identification | `lower/state_graph.go:ToStateGraph`; `state_executor.go:686` initialize | `state_simple.sysml` | ✅ Faithful |
+| Final state termination | `state_executor.go:288` processNextEvent | `state_simple.sysml` | ✅ Faithful |
+| State entry actions | `state_executor.go:749` enterState | `state_do_behavior.sysml` | ✅ Faithful |
+| State exit actions | `state_executor.go:810` exitState | `state_transition_effect.sysml` | ✅ Faithful |
+| State do behavior (immediate, not concurrent) | `state_executor.go:749` enterState | `state_do_behavior.sysml` | ⚠️ Approximate |
+| Transition firing | `state_executor.go:535` fireTransition | `state_transition_effect.sysml` | ✅ Faithful |
+| Transition guard evaluation | `state_executor.go:218` scheduleTransitionsForState | `state_choice_pseudostate.sysml` | ✅ Faithful |
+| Transition effect actions | `state_executor.go:535` fireTransition | `state_transition_effect.sysml` | ✅ Faithful |
+| AcceptEvent triggers (when signal) | `state_executor.go:401` matchesEvent | `state_signal_discriminate.sysml` | ✅ Faithful |
+| Sourceless transitions (`accept...then`) | `lower/state_graph.go:487` collectTransitions Usage case, `:302` resolve container | `accept_then_transition.sysml` | ✅ Faithful (nested form only; flat form errors intentionally) |
+| ChangeEvent triggers (when expr) | `state_executor.go:401` matchesEvent; `:906` pollChangeEvents | `state_executor_test.go:TestStateChangeEvent` | ✅ Faithful |
+| TimeEvent triggers (after/at) | `state_executor.go:401` matchesEvent | `state_executor_test.go:TestStateTimeEvent` | ✅ Faithful |
+| Signal discrimination | `state_executor.go:401` matchesEvent signal name | `state_signal_discriminate.sysml` | ✅ Faithful |
+| Unmatched signal dropped | `state_executor.go:401` matchesEvent | `state_signal_unmatched.sysml` | ✅ Faithful |
+| Hierarchical substates | `state_executor.go:131` getParentChain, `:147` getLCA | `state_orthogonal_regions.sysml` | ✅ Faithful |
+| Orthogonal regions | `state_executor.go:364` broadcastEvent, `:466` fireTransitionInRegion | `state_orthogonal_regions.sysml` | ✅ Faithful |
+| Choice pseudostates | `state_executor.go:971` evaluateChoicePseudostate | `state_choice_pseudostate.sysml` | ✅ Faithful |
+| Junction pseudostates | `state_executor.go:1020` evaluateJunctionPseudostate | `state_junction_pseudostate.sysml` | ✅ Faithful |
+| Fork/Join/Entry/Exit/History pseudostates | `state_executor.go:552` fireTransition ("unsupported pseudostate kind") | — | ❌ Not Yet Implemented |
+| CallEvent operation-name matching | `state_executor.go:437` matchesEvent (matches any call, TODO) | — | ⚠️ Approximate |
+| Nested action invocation in entry/exit/effect | `state_executor.go:862` executeAction ("not yet implemented") | — | ❌ Not Yet Implemented |
+| Run-to-completion semantics | `state_executor.go:288` processNextEvent | `state_executor_test.go:TestStateRunToCompletion` | ✅ Faithful |
+| Event queue management | `state_executor.go:1127` EventQueue | `state_executor_test.go` | ✅ Faithful |
+| Dangling transition detection | `robustness_test.go:testStateDanglingTransition` (lenient) | `robustness_test.go:testStateDanglingTransition` | ⚠️ Approximate |
+| Completion transitions | `state_executor.go:218` scheduleTransitionsForState nil trigger | `state_simple.sysml` | ✅ Faithful |
 
 ### Expression Evaluation
 
 | Semantic Rule | Implementation | Test Case | Status |
 |--------------|----------------|-----------|--------|
-| Binary operators (+, -, *, /, <, >, ==) | `eval.go:203` evalBinaryOp | `calc_simple_add.sysml` | ✅ Faithful |
-| Boolean operators (and, or) | `eval.go:203` evalBinaryOp | `constraint_literal.sysml` | ✅ Faithful |
-| Unary operators (-, not) | `eval.go:485` evalNeg | `calc_unary_operators.sysml` | ✅ Faithful |
-| Literal values (Integer, Real, Boolean, String) | `eval.go:140` evalLiteralExpr | `calc_simple_add.sysml` | ✅ Faithful |
-| Feature reference resolution | `eval.go:150` evalFeatureRef | `constraint_literal.sysml` | ✅ Faithful |
-| Qualified name resolution (A::B::C) | `eval.go:176` evalQualifiedName | `calc_qualified_names.sysml` | ✅ Faithful |
-| Type coercion (Integer→Real) | `eval.go:346` toReal | `calc_type_coercion.sysml` | ✅ Faithful |
+| Binary operators (+, -, *, /, <, >, ==) | `eval.go:265` evalOperator | `calc_simple_add.sysml` | ✅ Faithful |
+| Boolean operators (and, or) | `eval.go:435` evalLogical | `constraint_literal.sysml` | ✅ Faithful |
+| Unary operators (-, not) | `eval.go:483` evalNeg | `calc_unary_operators.sysml` | ✅ Faithful |
+| Literal values (Integer, Real, Boolean, String) | `eval.go:109` evalLiteral* | `calc_simple_add.sysml` | ✅ Faithful |
+| Feature reference resolution | `eval.go:141` evalFeatureReference | `constraint_literal.sysml` | ✅ Faithful |
+| Qualified name resolution (A::B::C) | `eval.go:53` Eval + `resolve/qualified.go` | `calc_qualified_names.sysml` | ✅ Faithful |
+| Type coercion (Integer→Real) | `eval.go:344` toReal | `calc_type_coercion.sysml` | ✅ Faithful |
 
 ### Name Resolution
 
@@ -277,14 +281,14 @@ Each row documents one behavioral semantic feature:
 
 | File | Purpose | Lines |
 |------|---------|-------|
-| `context.go` | Execution context, calc/constraint/requirement evaluation | ~500 |
-| `action_executor.go` | Token-flow semantics, control flow nodes, nested actions | ~850 |
-| `state_executor.go` | Event-driven state machines, transitions, hierarchical states, pseudostates | ~1000 |
-| `eval.go` | Expression evaluation (operators, literals, features) | ~600 |
+| `context.go` | Execution context, calc/constraint/requirement evaluation | ~460 |
+| `action_executor.go` | Token-flow semantics, control flow nodes, nested actions | ~729 |
+| `state_executor.go` | Event-driven state machines, transitions, hierarchical states, pseudostates | ~1149 |
+| `eval.go` | Expression evaluation (operators, literals, features) | ~758 |
 | `value.go` | Runtime value representation (ValConst, ValString, ValInstance) | ~150 |
-| `trace.go` | Deterministic execution trace recording | ~170 |
-| `conformance_test.go` | Conformance gate (25 cases) | ~470 |
-| `robustness_test.go` | Failure-mode tests (6 cases) | ~360 |
+| `trace.go` | Deterministic execution trace recording | ~154 |
+| `conformance_test.go` | Conformance gate (26 cases) | ~470 |
+| `robustness_test.go` | Failure-mode tests (7 cases) | ~360 |
 | `trace_test.go` | Golden trace test infrastructure | ~140 |
 
 ### Symbol Resolution (`internal/core/resolve/`)
@@ -308,26 +312,26 @@ Each row documents one behavioral semantic feature:
 See [`TESTING.md`](TESTING.md) for complete test contract details.
 
 **Test Counts:**
-- Conformance cases: 20 (all passing)
-- Robustness tests: 6 (all passing)
+- Conformance cases: 26 (all passing)
+- Robustness tests: 7 (all passing)
 - Unit tests: 41 (action/state executors)
-- Golden AST fixtures: 19
-- Negative parser tests: 16
+- Golden AST fixtures: 16
+- Negative parser tests: 15
 - Total tests: 900+
 
 **Coverage by Feature Type:**
 - Calc: 4 conformance + 3 unit + 2 robustness
 - Constraint: 3 conformance + 1 robustness
 - Requirement: 5 conformance + 4 unit (named args, inheritance)
-- Action: 3 conformance + 19 unit + 1 robustness
-- State: 2 conformance + 14 unit + 1 robustness
+- Action: 5 conformance + 19 unit + 1 robustness
+- State: 9 conformance + 14 unit + 2 robustness
 - Evaluation: 3 conformance (unary, coercion, qualified)
 - Name resolution: 3 unit (inheritance, named args, control flow)
 
 **Quality Gates:**
 - Parser: 94/94 stdlib files clean
-- Conformance: 20/20 cases passing
-- Training examples: 69/100 clean (31 with pedagogical gaps or OMG bugs)
+- Conformance: 26/26 cases passing
+- Training examples: 63/100 clean (37 with pedagogical gaps or OMG bugs)
 - No regressions: All tests pass on every commit
 
 ---

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -73,7 +73,7 @@ Future work: If SysML printer added, verify `parse(print(parse(input))) == parse
 **Purpose:** Verify parser rejects malformed input gracefully
 
 - **Test:** `TestNegative` (internal/core/parser/)
-- **Coverage:** 16 malformed inputs (7 behavioral + 9 structural)
+- **Coverage:** 15 malformed inputs (6 behavioral + 9 structural)
 - **Acceptance:** Each case produces diagnostics (never panics)
 
 **Examples:**
@@ -112,12 +112,12 @@ New behavioral features (actions, states, calc, constraints, requirements) requi
 - **Schema:** `internal/core/runtime/testdata/conformance/README.md`
 - **Allowlist:** `known_failures.txt` (currently empty)
 
-**Coverage (20 cases - all passing):**
-- Calc: parameter binding, return values, unary ops, qualified names, type coercion
-- Constraint: assert, assume, negation
-- Requirement: require, subject, actor, assume, nested
-- Action: token flow, outputs, nested invocation, send/accept, port communication
-- State: transitions, entry/do/exit, final state, transition effects
+**Coverage (26 cases - all passing):**
+- Calc: parameter binding, return values, unary ops, qualified names, type coercion (×4)
+- Constraint: assert, assume, negation (×3)
+- Requirement: require, subject, actor, assume, nested (×5)
+- Action: token flow, outputs, nested invocation, send/accept, port communication (×5)
+- State: simple, do behavior, transition effect, choice/junction pseudostates, orthogonal regions, signal discrimination/unmatched, accept...then (×9)
 
 ```bash
 go test -v -run TestExecutionConformance ./internal/core/runtime
@@ -146,13 +146,14 @@ go test -run TestExecutionTrace -update-traces ./internal/core/runtime
 **Purpose:** Verify malformed/pathological behaviors fail gracefully
 
 - **Test:** `TestRuntimeRobustness` (internal/core/runtime/)
-- **Coverage:** 6 failure modes
+- **Coverage:** 7 failure modes
 - **Acceptance:** Typed errors, never panic, 60s timeout guard
 
 **Failure modes:**
 - Deadlocked action (join starvation)
 - Decision with no satisfied guard
 - State machine with dangling transition
+- Sourceless accept...then at top level
 - Calc with unbound parameter
 - Constraint referencing missing feature
 - Step budget exceeded

--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -22,14 +22,13 @@ Grammar conformance is validated through parsing **OMG's own files**:
    - See: `internal/core/libs/stdlib_conformance_test.go`
    - These files are the **source of truth** for correct parsing
 
-2. **Training Examples** - 100 OMG training files (69/100 parse clean)
-   - Download: `./scripts/download-training-examples.sh`
+2. **Training Examples** - 100 OMG training files (63/100 parse clean)
    - See: `docs/TRAINING_EXAMPLES.md`
 
 3. **Golden AST Tests** - 16 fixtures with expected AST output
    - See: `internal/core/parser/testdata/parse/`
 
-4. **Negative Tests** - 16 test cases for error recovery
+4. **Negative Tests** - 15 test cases for error recovery
    - See: `internal/core/parser/negative_test.go`
 
 ## Hand-Written Parser
@@ -39,5 +38,3 @@ The parser is hand-written for:
 - **Error Recovery** - Custom ErrorNode insertion for fault tolerance
 - **Control** - Full control over diagnostic messages
 - **Incremental Parsing** - Future LSP support
-
-See `docs/adr/0001-parser-strategy.md` for the decision rationale.

--- a/internal/core/lower/state_graph.go
+++ b/internal/core/lower/state_graph.go
@@ -287,7 +287,7 @@ func lowerTransitionEdge(graph *StateGraph, edge *ast.TransitionEdge) (*Transiti
 
 // lowerTransitionMember converts a TransitionMember (parser output) to a Transition.
 // containingState is used as the source when member.Source is nil (sourceless accept...then).
-func lowerTransitionMember(graph *StateGraph, member *ast.TransitionMember, containingState *ast.StateNode) (*Transition, error) {
+func lowerTransitionMember(graph *StateGraph, member *ast.TransitionMember, containingState ast.Node) (*Transition, error) {
 	// TransitionMember has: Source (QualifiedName), Target (QualifiedName), Trigger, Guard, Effect ([]Node)
 	// Source and Target can be StateNode or PseudostateNode
 	// Source can be nil for sourceless transitions (accept...then) - use containingState
@@ -299,7 +299,29 @@ func lowerTransitionMember(graph *StateGraph, member *ast.TransitionMember, cont
 		if containingState == nil {
 			return nil, fmt.Errorf("sourceless transition (accept...then) at top level has no containing state")
 		}
-		source = containingState
+
+		// containingState could be *ast.Usage (for state X { ... }) or *ast.StateNode
+		// Need to find the corresponding StateNode in graph.States
+		switch cs := containingState.(type) {
+		case *ast.StateNode:
+			source = cs
+		case *ast.Usage:
+			// Find the StateNode that corresponds to this Usage
+			// Match by checking if the Usage is the source of any state
+			for _, s := range graph.States {
+				// StateNode typically comes from the same parse tree - check identity
+				// Or match by name if available
+				if s.Name == cs.Ident.Name {
+					source = s
+					break
+				}
+			}
+			if source == nil {
+				return nil, fmt.Errorf("could not resolve containing state Usage %q to StateNode", cs.Ident.Name)
+			}
+		default:
+			return nil, fmt.Errorf("containing state has unexpected type %T", containingState)
+		}
 	} else {
 		sourceState := findStateByName(graph.States, member.Source)
 		if sourceState != nil {
@@ -407,7 +429,7 @@ func classifyTrigger(trigger ast.Node) ast.Node {
 // Handles top-level members and region members.
 // regionStates limits state lookup to states within a specific region (nil = all states).
 // containingState is the enclosing state for sourceless transitions (nil at top level).
-func collectTransitions(graph *StateGraph, memberList []ast.Node, regionStates []*ast.StateNode, containingState *ast.StateNode) error {
+func collectTransitions(graph *StateGraph, memberList []ast.Node, regionStates []*ast.StateNode, containingState ast.Node) error {
 
 	for _, member := range memberList {
 		actualMember := unwrapMembership(member)
@@ -461,6 +483,13 @@ func collectTransitions(graph *StateGraph, memberList []ast.Node, regionStates [
 							graph.Transitions[sourceState] = append(graph.Transitions[sourceState], trans)
 						}
 					}
+				}
+			} else if n.Kind == ast.UsageState && len(n.Members) > 0 {
+				// Handle state usages (state X { ... }) - recurse into members
+				// This state usage can contain transitions (accept...then, etc.)
+				// Pass this Usage node as the containing state for sourceless transitions
+				if err := collectTransitions(graph, n.Members, nil, n); err != nil {
+					return err
 				}
 			}
 		case *ast.InitialNode:

--- a/internal/core/lower/state_graph.go
+++ b/internal/core/lower/state_graph.go
@@ -139,7 +139,7 @@ func ToStateGraph(stateMachineDecl ast.Node) (*StateGraph, error) {
 	}
 
 	// Third pass: collect transitions
-	if err := collectTransitions(graph, members, nil); err != nil {
+	if err := collectTransitions(graph, members, nil, nil); err != nil {
 		return nil, err
 	}
 
@@ -286,34 +286,44 @@ func lowerTransitionEdge(graph *StateGraph, edge *ast.TransitionEdge) (*Transiti
 }
 
 // lowerTransitionMember converts a TransitionMember (parser output) to a Transition.
-func lowerTransitionMember(graph *StateGraph, member *ast.TransitionMember) (*Transition, error) {
+// containingState is used as the source when member.Source is nil (sourceless accept...then).
+func lowerTransitionMember(graph *StateGraph, member *ast.TransitionMember, containingState *ast.StateNode) (*Transition, error) {
 	// TransitionMember has: Source (QualifiedName), Target (QualifiedName), Trigger, Guard, Effect ([]Node)
 	// Source and Target can be StateNode or PseudostateNode
+	// Source can be nil for sourceless transitions (accept...then) - use containingState
 
 	// Try to find source as state
 	var source ast.Node
-	sourceState := findStateByName(graph.States, member.Source)
-	if sourceState != nil {
-		source = sourceState
+	if member.Source == nil {
+		// Sourceless transition - use containing state
+		if containingState == nil {
+			return nil, fmt.Errorf("sourceless transition (accept...then) at top level has no containing state")
+		}
+		source = containingState
 	} else {
-		// Try pseudostate
-		sourceName := member.Source.Parts[len(member.Source.Parts)-1].Text
-		if ps, ok := graph.Pseudostates[sourceName]; ok {
-			source = ps
+		sourceState := findStateByName(graph.States, member.Source)
+		if sourceState != nil {
+			source = sourceState
+		} else {
+			// Try pseudostate
+			sourceName := member.Source.Parts[len(member.Source.Parts)-1].Text
+			if ps, ok := graph.Pseudostates[sourceName]; ok {
+				source = ps
+			}
 		}
-	}
 
-	if source == nil {
-		// Debug: print available states and pseudostates
-		var stateNames []string
-		for _, s := range graph.States {
-			stateNames = append(stateNames, s.Name)
+		if source == nil {
+			// Debug: print available states and pseudostates
+			var stateNames []string
+			for _, s := range graph.States {
+				stateNames = append(stateNames, s.Name)
+			}
+			for name := range graph.Pseudostates {
+				stateNames = append(stateNames, name+" (pseudostate)")
+			}
+			return nil, fmt.Errorf("transition member references undefined source %q (available: %v)",
+				member.Source.Parts[len(member.Source.Parts)-1].Text, stateNames)
 		}
-		for name := range graph.Pseudostates {
-			stateNames = append(stateNames, name+" (pseudostate)")
-		}
-		return nil, fmt.Errorf("transition member references undefined source %q (available: %v)",
-			member.Source.Parts[len(member.Source.Parts)-1].Text, stateNames)
 	}
 
 	// Try to find target as state or pseudostate
@@ -396,7 +406,8 @@ func classifyTrigger(trigger ast.Node) ast.Node {
 // collectTransitions recursively processes member lists to collect transitions.
 // Handles top-level members and region members.
 // regionStates limits state lookup to states within a specific region (nil = all states).
-func collectTransitions(graph *StateGraph, memberList []ast.Node, regionStates []*ast.StateNode) error {
+// containingState is the enclosing state for sourceless transitions (nil at top level).
+func collectTransitions(graph *StateGraph, memberList []ast.Node, regionStates []*ast.StateNode, containingState *ast.StateNode) error {
 
 	for _, member := range memberList {
 		actualMember := unwrapMembership(member)
@@ -496,11 +507,17 @@ func collectTransitions(graph *StateGraph, memberList []ast.Node, regionStates [
 			graph.Transitions[trans.Source] = append(graph.Transitions[trans.Source], trans)
 		case *ast.TransitionMember:
 			// New: TransitionMember from parser (declarative)
-			trans, err := lowerTransitionMember(graph, n)
+			trans, err := lowerTransitionMember(graph, n, containingState)
 			if err != nil {
 				return err
 			}
 			graph.Transitions[trans.Source] = append(graph.Transitions[trans.Source], trans)
+		case *ast.StateNode:
+			// Recurse into state substates to collect transitions within the state
+			// Transitions inside this state have this state as their containing state
+			if err := collectTransitions(graph, n.Substates, nil, n); err != nil {
+				return err
+			}
 		case *ast.StateRegion:
 			// Collect states that belong to this region
 			// We need to find which states in graph.States came from this region
@@ -527,7 +544,8 @@ func collectTransitions(graph *StateGraph, memberList []ast.Node, regionStates [
 			}
 
 			// Recurse into region members with scoped state list
-			if err := collectTransitions(graph, n.States, statesInRegion); err != nil {
+			// Regions are orthogonal - transitions within them don't inherit a containing state
+			if err := collectTransitions(graph, n.States, statesInRegion, nil); err != nil {
 				return err
 			}
 		}

--- a/internal/core/parser/behavior.go
+++ b/internal/core/parser/behavior.go
@@ -2140,28 +2140,22 @@ func (p *Parser) parseAcceptTransition(start int) ast.Node {
 	// Expect semicolon
 	p.expect(lexer.Semicolon, "expected ';' after accept transition")
 
-	// Create transition usage with accept trigger
-	// For now, represent as transition usage (specialized connector)
-	transition := &ast.Usage{
-		Kind: ast.UsageTransition,
-		// Store signal type as first connector end, target state as second
-		ConnectorEnds: []*ast.ConnectorEnd{
-			{Reference: signalType},  // trigger
-			{Reference: targetState}, // target
-		},
-	}
-
-	// Store guard, effect, and via in Members (could extend AST for proper transition fields)
-	if guardExpr != nil {
-		// Wrap guard in membership for now
-		transition.Members = append(transition.Members, guardExpr)
-	}
+	// Create TransitionMember (proper transition representation)
+	// Source is nil - will be resolved to containing state at lowering
+	var effects []ast.Node
 	if effectAction != nil {
-		transition.Members = append(transition.Members, effectAction)
+		effects = append(effects, effectAction)
 	}
 	if viaPort != nil {
-		// Store via port as member (could use relationship or dedicated field)
-		transition.Members = append(transition.Members, viaPort)
+		effects = append(effects, viaPort)
+	}
+
+	transition := &ast.TransitionMember{
+		Source:  nil, // No explicit source - resolve to containing state
+		Target:  targetState,
+		Trigger: signalType,
+		Guard:   guardExpr,
+		Effect:  effects,
 	}
 
 	transition.NodeSpan = p.spanFrom(start)

--- a/internal/core/runtime/robustness_test.go
+++ b/internal/core/runtime/robustness_test.go
@@ -19,6 +19,7 @@ func TestRuntimeRobustness(t *testing.T) {
 	t.Run("deadlock_join_starvation", testDeadlockJoinStarvation)
 	t.Run("decision_no_satisfied_guard", testDecisionNoSatisfiedGuard)
 	t.Run("state_dangling_transition", testStateDanglingTransition)
+	t.Run("sourceless_accept_at_top_level", testSourcelessAcceptAtTopLevel)
 	t.Run("calc_unbound_parameter", testCalcUnboundParameter)
 	t.Run("constraint_missing_feature", testConstraintMissingFeature)
 	t.Run("step_budget_exceeded", testStepBudgetExceeded)
@@ -158,7 +159,49 @@ func testStateDanglingTransition(t *testing.T) {
 	t.Log("ProcessNextEvent succeeded (dangling transition not exercised)")
 }
 
-// testCalcUnboundParameter: calc invoked with missing parameter
+// testSourcelessAcceptAtTopLevel: sourceless accept...then at top level should error
+func testSourcelessAcceptAtTopLevel(t *testing.T) {
+	src := `
+		package test {
+			state Machine {
+				initial init;
+				state waiting;
+				state active;
+				init then waiting;
+				accept go then active; // ERROR: sourceless at top level
+			}
+		}
+	`
+	file := parseAndBuild(t, src)
+	if file == nil {
+		t.Fatal("parse failed")
+	}
+
+	idx, model, ctx := buildRuntime(t, "<test>", file)
+
+	_ = model // silence unused
+
+	rootScope := idx.DocumentRoot("<test>")
+	sym := findSymbolByName(rootScope, "Machine", ast.DefState)
+	if sym == nil {
+		t.Fatal("Machine state not found")
+	}
+
+	// Should fail at CreateStateExecutor (lowering time) with clear error
+	exec, err := ctx.CreateStateExecutor(sym)
+	if err != nil {
+		if strings.Contains(err.Error(), "sourceless") && strings.Contains(err.Error(), "containing state") {
+			t.Logf("CreateStateExecutor error (expected): %v", err)
+			return
+		}
+		t.Fatalf("Unexpected error message: %v", err)
+	}
+
+	if exec != nil {
+		t.Error("Expected error for sourceless accept...then at top level, but CreateStateExecutor succeeded")
+	}
+}
+
 func testCalcUnboundParameter(t *testing.T) {
 	src := `
 		package test {
@@ -199,8 +242,9 @@ func testCalcUnboundParameter(t *testing.T) {
 		return
 	}
 
-	t.Logf("InvokeCalc returned: %v (no error - implementation tolerates missing param)", result)
+	t.Logf("InvokeCalc returned value (unbound parameter accepted): %+v", result)
 }
+
 
 // testConstraintMissingFeature: constraint references nonexistent feature
 func testConstraintMissingFeature(t *testing.T) {

--- a/internal/core/runtime/robustness_test.go
+++ b/internal/core/runtime/robustness_test.go
@@ -245,7 +245,6 @@ func testCalcUnboundParameter(t *testing.T) {
 	t.Logf("InvokeCalc returned value (unbound parameter accepted): %+v", result)
 }
 
-
 // testConstraintMissingFeature: constraint references nonexistent feature
 func testConstraintMissingFeature(t *testing.T) {
 	src := `

--- a/internal/core/runtime/testdata/conformance/accept_then_transition.expected.json
+++ b/internal/core/runtime/testdata/conformance/accept_then_transition.expected.json
@@ -1,0 +1,9 @@
+{
+  "type": "state",
+  "symbol_fqn": "Test::Machine",
+  "events": [
+    {"name": "go"}
+  ],
+  "expected_states_visited": ["waiting", "active"],
+  "expected_final_state": "active"
+}

--- a/internal/core/runtime/testdata/conformance/accept_then_transition.expected.json
+++ b/internal/core/runtime/testdata/conformance/accept_then_transition.expected.json
@@ -1,9 +1,8 @@
 {
   "type": "state",
-  "symbol_fqn": "Test::Machine",
   "events": [
-    {"name": "go"}
+    {"signal": "go"}
   ],
-  "expected_states_visited": ["waiting", "active"],
-  "expected_final_state": "active"
+  "stateVisits": ["init", "waiting", "active", "done"],
+  "finalState": "done"
 }

--- a/internal/core/runtime/testdata/conformance/accept_then_transition.sysml
+++ b/internal/core/runtime/testdata/conformance/accept_then_transition.sysml
@@ -1,0 +1,14 @@
+package Test {
+    state Machine {
+        initial init;
+        state waiting {
+            // Sourceless accept-then transition: inside waiting, accept 'go' and transition to active
+            accept go then active;
+        }
+        state active;
+        final done;
+        
+        init then waiting;
+        active then done;
+    }
+}


### PR DESCRIPTION
## Problem

`accept...then` transitions without explicit source states were being dropped during lowering, causing state machines to fail initialization or execute incorrectly.

**Example that was broken:**
```sysml
state Machine {
    initial init;
    state waiting {
        accept go then active;  // This transition vanished
    }
    state active;
    init then waiting;
}
```

**Root Cause:**
- Parser emitted `UsageTransition` for `accept...then` syntax
- `collectTransitions()` in `state_graph.go` had no case to handle `UsageTransition`
- Transitions parsed successfully but were never collected into the state graph
- Additionally, state body members like `state waiting { ... }` parse as `*ast.Usage{UsageState}` (not `*ast.StateNode`), and transitions inside them lived in `Usage.Members` which were never traversed

## Solution

### Parser Changes (`behavior.go`)
- `parseAcceptTransition` now emits `TransitionMember` (instead of `UsageTransition`)
- `Source` field is `nil` for sourceless transitions (resolved during lowering)
- `Target`, `Trigger`, `Guard`, `Effect` properly populated

### Lowering Changes (`state_graph.go`)
- Added `containingState ast.Node` parameter to `collectTransitions()`
- Added case for `*ast.Usage{Kind: UsageState}` to recurse into state body members
- `lowerTransitionMember()` now resolves `nil` source to containing state
- Top-level sourceless transitions intentionally error: "sourceless transition at top level has no containing state"

## Testing

### Conformance Test
- `accept_then_transition.sysml`: State machine with nested `accept...then` transition
- Verifies transition fires correctly: `init → waiting → active → done`

### Robustness Test
- `testSourcelessAcceptAtTopLevel`: Verifies flat-form (top-level) sourceless transitions error as designed

### Full Gate
```bash
go test ./...         # All tests pass
gofmt -l .            # Clean
```

## Documentation

- **SPEC_COMPLIANCE.md**: Added row for sourceless transitions
  - Nested form (inside state body): ✅ Faithful
  - Flat form (top-level): Errors intentionally per design

## Commits

1. **f05a6af** - Core fix: Parser + lowering changes, conformance test
2. **b92fe96** - Documentation: SPEC_COMPLIANCE row, robustness test

## Migration

No breaking changes. This fix enables previously-broken syntax to work correctly.

**Before:** Sourceless `accept...then` silently dropped
**After:** Nested form works, flat form errors clearly

## Limitations

- Name-based resolution for containing state (could mis-resolve with duplicate state names in different scopes)
- Flat form intentionally errors (could be supported if semantic need identified)