### PR TITLE
Github.io page and SonarCloud fixes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+name: Pages
+
+# The site is docs/ rendered by MkDocs, republished when a page or the site
+# configuration changes on main. --strict: a broken link fails the deployment.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'docs-requirements.txt'
+      - 'scripts/mkdocs_repo_links.py'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time; cancelling one in flight would leave the site behind.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build the site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: docs-requirements.txt
+
+      - name: Install the toolchain
+        run: pip install -r docs-requirements.txt
+
+      - uses: actions/configure-pages@v5
+
+      - name: Build
+        run: mkdocs build --strict --site-dir site
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,9 @@ concurrency:
 jobs:
   build:
     name: Build the site
+    # The site is published from Open-MBEE/OpenSysML; a fork would deploy the same
+    # pages under its own domain.
+    if: github.repository == 'Open-MBEE/OpenSysML'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -222,6 +222,26 @@ jobs:
           name: vscode-extension
           path: editors/vscode/opensysml-sysml.vsix
 
+  docs:
+    name: Documentation site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: docs-requirements.txt
+
+      - name: Install the toolchain
+        run: pip install -r docs-requirements.txt
+
+      # --strict: a link or anchor a moved page left behind fails here rather than
+      # publishing a 404 from main.
+      - name: Build the site
+        run: mkdocs build --strict --site-dir site
+
   python-test:
     name: Python client tests
     needs: build-and-test

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /sysml
 /sysml-lsp
 
+# Rendered documentation site (make docs)
+/site/
+
 # Downloaded training examples (run scripts/download-training-examples.sh)
 /examples/sysml-v2-training/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,7 +249,8 @@ github.com/Open-MBEE/OpenSysML
 ## Documentation
 
 Documentation is organized by what a reader wants, not by the feature that landed. Four areas,
-mapped in [docs/README.md](docs/README.md):
+mapped in [docs/README.md](docs/README.md) and published as
+<https://jpl-devin.github.io/OpenSysML/>:
 
 - **[docs/guide/](docs/guide/)** — *how do I use it?* A numbered handbook read in order.
 - **[docs/reference/](docs/reference/)** — *what does this flag, command, API or triple mean?*
@@ -272,6 +273,9 @@ When a change needs documenting:
   [docs/project/roadmap.md](docs/project/roadmap.md) and
   [docs/project/training-examples.md](docs/project/training-examples.md). Recount all four
   together, in one commit.
+- **A new page goes in the `nav:` of [mkdocs.yml](mkdocs.yml)**, in the reading order of its
+  area, or it is published but unreachable from the site's navigation. `make docs-install`
+  once, then `make docs` builds the site the way CI does and `make docs-serve` previews it.
 - **Moving or renaming a page means updating its inbound links.** Run
   `python3 scripts/check-doc-links.py` — it fails on a link to a missing file or heading and
   runs in CI. Where a released `README.md` linked the old path, leave a one-paragraph pointer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,7 +250,7 @@ github.com/Open-MBEE/OpenSysML
 
 Documentation is organized by what a reader wants, not by the feature that landed. Four areas,
 mapped in [docs/README.md](docs/README.md) and published as
-<https://jpl-devin.github.io/OpenSysML/>:
+<https://open-mbee.github.io/OpenSysML/>:
 
 - **[docs/guide/](docs/guide/)** — *how do I use it?* A numbered handbook read in order.
 - **[docs/reference/](docs/reference/)** — *what does this flag, command, API or triple mean?*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-sysml build-lsp build-grpc test lint clean install help python-test python-install python-proto vscode-grammar vscode-build vscode-package
+.PHONY: all build build-sysml build-lsp build-grpc test lint clean install help python-test python-install python-proto vscode-grammar vscode-build vscode-package docs docs-install docs-serve
 
 # Version information
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -21,6 +21,7 @@ BIN_DIR := bin
 PYTHON_DIR := python
 VSCODE_DIR := editors/vscode
 PYTHON ?= python3
+SITE_DIR := site
 
 all: build test python-test ## Build and test everything
 
@@ -66,6 +67,7 @@ clean: ## Remove build artifacts
 	rm -rf $(BIN_DIR)
 	rm -f coverage.txt
 	rm -f sysml sysml-lsp sysml-grpc
+	rm -rf $(SITE_DIR)
 	@echo "✓ Cleaned"
 
 install: build ## Install binaries to $GOPATH/bin
@@ -118,6 +120,17 @@ vscode-package: ## Package the VS Code extension as a .vsix for side-loading
 	@echo "Packaging the VS Code extension..."
 	cd $(VSCODE_DIR) && npm ci && npm run package
 	@echo "✓ Packaged $(VSCODE_DIR)/opensysml-sysml.vsix"
+
+docs-install: ## Install the documentation site toolchain
+	$(PYTHON) -m pip install -r docs-requirements.txt
+
+docs: ## Build the documentation site, failing on a broken link
+	@echo "Building the documentation site..."
+	$(PYTHON) -m mkdocs build --strict --site-dir $(SITE_DIR)
+	@echo "✓ Built $(SITE_DIR)/"
+
+docs-serve: ## Serve the documentation site with live reload
+	$(PYTHON) -m mkdocs serve --strict
 
 help: ## Show this help message
 	@echo "Available targets:"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A complete, production-grade SysML v2 implementation in Go—providing language 
 
 **Get started in 5 minutes:** [the guide](docs/guide/)
 
+**All documentation, searchable:** <https://jpl-devin.github.io/OpenSysML/> — the same
+pages as [docs/](docs/), rendered from `main`.
+
 ### Install
 
 **Download pre-built binaries:**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A complete, production-grade SysML v2 implementation in Go—providing language 
 
 **Get started in 5 minutes:** [the guide](docs/guide/)
 
-**All documentation, searchable:** <https://jpl-devin.github.io/OpenSysML/> — the same
+**All documentation, searchable:** <https://open-mbee.github.io/OpenSysML/> — the same
 pages as [docs/](docs/), rendered from `main`.
 
 ### Install

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,4 @@
+# The documentation site toolchain, pinned so a local `make docs-serve` renders
+# what the Pages workflow publishes.
+mkdocs==1.6.1
+mkdocs-material==9.7.7

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -1,0 +1,11 @@
+# Internals
+
+How it works, for someone changing the code. What the code does for a user is
+[the guide](../guide/) and [the reference](../reference/).
+
+- **[Architecture](architecture.md)** — the pipeline, the tiers, the test contracts
+- **[Testing](testing.md)** — the test contracts each kind of change must satisfy
+- **[Performance](performance.md)** — profiling, and what a large model costs
+- **[Design notes](design/README.md)** — how a subsystem was built, and against which
+  normative reference
+- **[Plans](notes/README.md)** — the staged work behind a subsystem, kept for its rationale

--- a/docs/internals/design/README.md
+++ b/docs/internals/design/README.md
@@ -1,0 +1,18 @@
+# Design notes
+
+How a subsystem is built and which normative reference it answers to. For
+maintainers; the behavior a user sees is [the guide](../../guide/).
+
+- **[The action executor](action-executor.md)** — how a token moves through a lowered
+  `ActionGraph`
+- **[Orthogonal regions](orthogonal-regions.md)** — concurrent substates, an OpenSysML
+  extension against UML 2.5.1 semantics
+- **[Pseudostates](pseudostates.md)** — choice, junction, fork, join, entry/exit points
+  and history
+- **[Python gRPC bindings](python-grpc-bindings.md)** — the service and client design
+
+The staged plans that built the bindings, kept for their rationale:
+[phase 1](python-grpc-phase1-plan.md) (the service),
+[phase 2](python-grpc-phase2-plan.md) (the client),
+[phase 3](python-grpc-phase3-plan.md) and its [fixes](python-grpc-phase3-fixes.md),
+[phase 4](python-grpc-phase4-plan.md).

--- a/docs/internals/notes/README.md
+++ b/docs/internals/notes/README.md
@@ -1,0 +1,11 @@
+# Plans
+
+Staged work, kept after delivery for the rationale rather than the checklist: the
+current contracts are in [architecture](../architecture.md) and
+[testing](../testing.md).
+
+- **[Behavior robustness](behavior-robustness-plan.md)** — the executors and their failure
+  modes, phases B1–B6
+- **[Lowering integration](lowering-integration-plan.md)** — moving execution onto the
+  `ActionGraph`/`StateGraph` IR
+- **[Parser robustness](parser-robustness-plan.md)** — how the parser came to never panic

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,0 +1,14 @@
+# Project
+
+Where the project stands: what is implemented, what is known to be missing, and how
+a release is cut.
+
+- **[Spec compliance](spec-compliance.md)** — faithful, approximate, or not implemented,
+  rule by rule
+- **[Training examples](training-examples.md)** — the OMG corpus, adjudicated per file
+- **[Roadmap](roadmap.md)** — the known gaps, in the order they should be picked up
+- **[Releasing](releasing.md)** — the pre-tag gate, tagging, artifacts, Homebrew
+- **[macOS distribution](macos-distribution.md)** — Gatekeeper and the signing decision
+- **[Bugs in the OMG materials](omg-issues.md)** — defects in the vendored specification
+  libraries
+- **[Demo](demo.md)** — a scripted walkthrough of the whole surface

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,13 @@
+# Reference
+
+Looking one thing up — every flag, command, symbol and triple, and nothing about
+why. The handbook that puts them in order is [the guide](../guide/).
+
+- **[CLI](cli.md)** — every flag of `sysml`, the modes, and the exit status
+- **[REPL commands](repl-commands.md)** — every `%` command and its arguments
+- **[Environment variables](environment.md)** — the bounds one run may spend, and paths
+- **[Go API](api.md)** — the public API of every package
+- **[Python API](python-api.md)** — `opensysml`, its generated typed classes and latency
+- **[RDF mapping](rdf-mapping.md)** — which triples a model becomes, what is not mapped, and
+  why the mapping is experimental
+- **[Grammar](grammar/README.md)** — grammar production → parser implementation

--- a/internal/core/rdf/ontology/README.md
+++ b/internal/core/rdf/ontology/README.md
@@ -53,9 +53,10 @@ SYSMLV2_RDF_ONTOLOGY=/path/to/sysmlv2-rdf-ontology go generate ./internal/core/r
 ```
 
 The generator reads the ontology version from the checkout's `sysml2/README.md`
-and the commit SHA from `git rev-parse HEAD`, refuses to write a table if any
-property has no `rdfs:domain` or if a property IRI disagrees with its domain, and
-overwrites `table.go` in place. Review the diff, then run
+and the commit SHA from the checkout's on-disk Git metadata. It does not need a
+`git` binary, refuses to write a table if any property has no `rdfs:domain` or
+if a property IRI disagrees with its domain, and overwrites `table.go` in place.
+Review the diff, then run
 `go test ./internal/core/rdf/ontology/... ./internal/core/export/...` — the
 export gate compares the golden graphs against the new table and will report
 anything the ontology bump changed.

--- a/internal/core/rdf/ontology/gen/main.go
+++ b/internal/core/rdf/ontology/gen/main.go
@@ -107,7 +107,7 @@ func run(root, out string) error {
 
 var (
 	versionBadge     = regexp.MustCompile(`Version-(\d+)-`)
-	commitSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	commitSHAPattern = regexp.MustCompile(`^([0-9a-f]{40}|[0-9a-f]{64})$`)
 )
 
 // ontologyVersion reads the metamodel version out of the checkout's own README

--- a/internal/core/rdf/ontology/gen/main.go
+++ b/internal/core/rdf/ontology/gen/main.go
@@ -14,7 +14,6 @@ import (
 	"go/format"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -106,7 +105,10 @@ func run(root, out string) error {
 	return nil
 }
 
-var versionBadge = regexp.MustCompile(`Version-(\d+)-`)
+var (
+	versionBadge     = regexp.MustCompile(`Version-(\d+)-`)
+	commitSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+)
 
 // ontologyVersion reads the metamodel version out of the checkout's own README
 // badge, so the recorded version cannot drift from the file it describes.
@@ -124,12 +126,148 @@ func ontologyVersion(path string) (string, error) {
 }
 
 func commitSHA(root string) (string, error) {
-	cmd := exec.Command("git", "-C", root, "rev-parse", "HEAD")
-	sha, err := cmd.Output()
+	gitDir, refsDir, err := gitMetadataDirs(root)
 	if err != nil {
-		return "", fmt.Errorf("read ontology commit: %w", err)
+		return "", err
 	}
-	return strings.TrimSpace(string(sha)), nil
+	headPath := filepath.Join(gitDir, "HEAD")
+	head, err := os.ReadFile(headPath)
+	if err != nil {
+		return "", gitMetadataErrorf(headPath, "read HEAD: %w", err)
+	}
+	headValue := strings.TrimSpace(string(head))
+	if strings.HasPrefix(headValue, "ref:") {
+		ref := strings.TrimSpace(strings.TrimPrefix(headValue, "ref:"))
+		if !validGitRef(ref) {
+			return "", gitMetadataErrorf(headPath, "invalid symbolic ref %q", ref)
+		}
+		return commitSHAForRef(refsDir, ref)
+	}
+	return validateCommitSHA(headValue, headPath)
+}
+
+type gitMetadataError struct {
+	path string
+	err  error
+}
+
+func (e *gitMetadataError) Error() string {
+	return fmt.Sprintf("git metadata %s: %v", e.path, e.err)
+}
+
+func (e *gitMetadataError) Unwrap() error {
+	return e.err
+}
+
+func gitMetadataErrorf(path, format string, args ...any) error {
+	return &gitMetadataError{path: path, err: fmt.Errorf(format, args...)}
+}
+
+func gitMetadataDirs(root string) (string, string, error) {
+	dotGit := filepath.Join(root, ".git")
+	info, err := os.Stat(dotGit)
+	if err != nil {
+		return "", "", gitMetadataErrorf(dotGit, "read .git: %w", err)
+	}
+	gitDir := dotGit
+	if !info.IsDir() {
+		data, err := os.ReadFile(dotGit)
+		if err != nil {
+			return "", "", gitMetadataErrorf(dotGit, "read gitdir: %w", err)
+		}
+		line := strings.TrimSpace(string(data))
+		const prefix = "gitdir:"
+		if !strings.HasPrefix(line, prefix) {
+			return "", "", gitMetadataErrorf(dotGit, "invalid gitdir file")
+		}
+		target := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		if target == "" {
+			return "", "", gitMetadataErrorf(dotGit, "empty gitdir path")
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(root, target)
+		}
+		gitDir = filepath.Clean(target)
+		info, err = os.Stat(gitDir)
+		if err != nil {
+			return "", "", gitMetadataErrorf(dotGit, "read gitdir %s: %w", gitDir, err)
+		}
+		if !info.IsDir() {
+			return "", "", gitMetadataErrorf(dotGit, "gitdir %s is not a directory", gitDir)
+		}
+	}
+
+	refsDir := gitDir
+	commondirPath := filepath.Join(gitDir, "commondir")
+	data, err := os.ReadFile(commondirPath)
+	if err == nil {
+		commonDir := strings.TrimSpace(string(data))
+		if commonDir == "" {
+			return "", "", gitMetadataErrorf(commondirPath, "empty common directory path")
+		}
+		if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(gitDir, commonDir)
+		}
+		refsDir = filepath.Clean(commonDir)
+		info, err := os.Stat(refsDir)
+		if err != nil {
+			return "", "", gitMetadataErrorf(commondirPath, "read common directory %s: %w", refsDir, err)
+		}
+		if !info.IsDir() {
+			return "", "", gitMetadataErrorf(commondirPath, "common directory %s is not a directory", refsDir)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", "", gitMetadataErrorf(commondirPath, "read common directory: %w", err)
+	}
+	return gitDir, refsDir, nil
+}
+
+func validGitRef(ref string) bool {
+	if !strings.HasPrefix(ref, "refs/") || strings.ContainsAny(ref, " \t\r\n") {
+		return false
+	}
+	for _, part := range strings.Split(ref, "/") {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func commitSHAForRef(refsDir, ref string) (string, error) {
+	loosePath := filepath.Join(refsDir, filepath.FromSlash(ref))
+	data, err := os.ReadFile(loosePath)
+	if err == nil {
+		return validateCommitSHA(strings.TrimSpace(string(data)), loosePath)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", gitMetadataErrorf(loosePath, "read ref %s: %w", ref, err)
+	}
+
+	packedPath := filepath.Join(refsDir, "packed-refs")
+	data, err = os.ReadFile(packedPath)
+	if err != nil {
+		return "", gitMetadataErrorf(packedPath, "read ref %s: %w", ref, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "^") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[1] != ref {
+			continue
+		}
+		return validateCommitSHA(fields[0], packedPath)
+	}
+	return "", gitMetadataErrorf(packedPath, "ref %s not found", ref)
+}
+
+func validateCommitSHA(sha, path string) (string, error) {
+	if !commitSHAPattern.MatchString(sha) {
+		return "", gitMetadataErrorf(path, "invalid commit SHA %q", sha)
+	}
+	return sha, nil
 }
 
 // declaration is one top-level RDF/XML declaration in the ontology: an

--- a/internal/core/rdf/ontology/gen/main.go
+++ b/internal/core/rdf/ontology/gen/main.go
@@ -131,6 +131,7 @@ func commitSHA(root string) (string, error) {
 		return "", err
 	}
 	headPath := filepath.Join(gitDir, "HEAD")
+	// #nosec G304 -- git metadata path derives from the requested checkout.
 	head, err := os.ReadFile(headPath)
 	if err != nil {
 		return "", gitMetadataErrorf(headPath, "read HEAD: %w", err)
@@ -171,6 +172,7 @@ func gitMetadataDirs(root string) (string, string, error) {
 	}
 	gitDir := dotGit
 	if !info.IsDir() {
+		// #nosec G304 -- .git is derived from the requested checkout.
 		data, err := os.ReadFile(dotGit)
 		if err != nil {
 			return "", "", gitMetadataErrorf(dotGit, "read gitdir: %w", err)
@@ -199,6 +201,7 @@ func gitMetadataDirs(root string) (string, string, error) {
 
 	refsDir := gitDir
 	commondirPath := filepath.Join(gitDir, "commondir")
+	// #nosec G304 -- commondir is inside the requested Git metadata directory.
 	data, err := os.ReadFile(commondirPath)
 	if err == nil {
 		commonDir := strings.TrimSpace(string(data))
@@ -236,6 +239,7 @@ func validGitRef(ref string) bool {
 
 func commitSHAForRef(refsDir, ref string) (string, error) {
 	loosePath := filepath.Join(refsDir, filepath.FromSlash(ref))
+	// #nosec G304 -- ref is validated before it is joined to the Git directory.
 	data, err := os.ReadFile(loosePath)
 	if err == nil {
 		return validateCommitSHA(strings.TrimSpace(string(data)), loosePath)
@@ -245,6 +249,7 @@ func commitSHAForRef(refsDir, ref string) (string, error) {
 	}
 
 	packedPath := filepath.Join(refsDir, "packed-refs")
+	// #nosec G304 -- packed-refs is inside the requested Git metadata directory.
 	data, err = os.ReadFile(packedPath)
 	if err != nil {
 		return "", gitMetadataErrorf(packedPath, "read ref %s: %w", ref, err)

--- a/internal/core/rdf/ontology/gen/main_test.go
+++ b/internal/core/rdf/ontology/gen/main_test.go
@@ -34,6 +34,14 @@ func TestCommitSHADetachedHead(t *testing.T) {
 	assertCommitSHA(t, root, testCommitSHA)
 }
 
+func TestCommitSHA256DetachedHead(t *testing.T) {
+	root := newGitTestRoot(t)
+	sha := strings.Repeat("a", 64)
+	writeGitTestFile(t, filepath.Join(root, ".git", "HEAD"), sha+"\n")
+
+	assertCommitSHA(t, root, sha)
+}
+
 func TestCommitSHAGitdirFile(t *testing.T) {
 	root := t.TempDir()
 	gitDir := filepath.Join(root, "gitdir")

--- a/internal/core/rdf/ontology/gen/main_test.go
+++ b/internal/core/rdf/ontology/gen/main_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testCommitSHA = "0123456789abcdef0123456789abcdef01234567"
+
+func TestCommitSHASymrefLooseRef(t *testing.T) {
+	root := newGitTestRoot(t)
+	writeGitTestFile(t, filepath.Join(root, ".git", "HEAD"), "ref: refs/heads/main\n")
+	writeGitTestFile(t, filepath.Join(root, ".git", "refs", "heads", "main"), testCommitSHA+"\n")
+
+	assertCommitSHA(t, root, testCommitSHA)
+}
+
+func TestCommitSHASymrefPackedRefs(t *testing.T) {
+	root := newGitTestRoot(t)
+	writeGitTestFile(t, filepath.Join(root, ".git", "HEAD"), "ref: refs/heads/main\n")
+	writeGitTestFile(t, filepath.Join(root, ".git", "packed-refs"),
+		"# pack-refs with: peeled fully-peeled\n"+testCommitSHA+" refs/heads/main\n")
+
+	assertCommitSHA(t, root, testCommitSHA)
+}
+
+func TestCommitSHADetachedHead(t *testing.T) {
+	root := newGitTestRoot(t)
+	writeGitTestFile(t, filepath.Join(root, ".git", "HEAD"), testCommitSHA+"\n")
+
+	assertCommitSHA(t, root, testCommitSHA)
+}
+
+func TestCommitSHAGitdirFile(t *testing.T) {
+	root := t.TempDir()
+	gitDir := filepath.Join(root, "gitdir")
+	if err := os.MkdirAll(gitDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeGitTestFile(t, filepath.Join(root, ".git"), "gitdir: gitdir\n")
+	writeGitTestFile(t, filepath.Join(gitDir, "HEAD"), testCommitSHA+"\n")
+
+	assertCommitSHA(t, root, testCommitSHA)
+}
+
+func TestCommitSHAMissingHead(t *testing.T) {
+	root := newGitTestRoot(t)
+
+	_, err := commitSHA(root)
+	assertGitMetadataError(t, err)
+	if !strings.Contains(err.Error(), filepath.Join(".git", "HEAD")) {
+		t.Fatalf("error %q does not name HEAD", err)
+	}
+}
+
+func TestCommitSHAMalformedHead(t *testing.T) {
+	root := newGitTestRoot(t)
+	writeGitTestFile(t, filepath.Join(root, ".git", "HEAD"), "deadbeef\n")
+
+	_, err := commitSHA(root)
+	assertGitMetadataError(t, err)
+	if !strings.Contains(err.Error(), "invalid commit SHA") {
+		t.Fatalf("error %q does not identify the invalid SHA", err)
+	}
+}
+
+func newGitTestRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func writeGitTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertCommitSHA(t *testing.T, root, want string) {
+	t.Helper()
+	got, err := commitSHA(root)
+	if err != nil {
+		t.Fatalf("commitSHA: %v", err)
+	}
+	if got != want {
+		t.Fatalf("commitSHA = %q, want %q", got, want)
+	}
+}
+
+func assertGitMetadataError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("commitSHA returned nil error")
+	}
+	var metadataErr *gitMetadataError
+	if !errors.As(err, &metadataErr) {
+		t.Fatalf("error %T is not a gitMetadataError: %v", err, err)
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,143 @@
+# The site is the docs/ tree unmodified: every page stays a Markdown file read on
+# GitHub, and MkDocs is only the renderer.
+site_name: OpenSysML
+site_description: A SysML v2 and KerML implementation in Go — language server, REPL, execution runtime, Python client
+site_url: https://jpl-devin.github.io/OpenSysML/
+repo_url: https://github.com/JPL-Devin/OpenSysML
+repo_name: JPL-Devin/OpenSysML
+edit_uri: edit/main/docs/
+copyright: Apache-2.0
+
+docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.top
+    - navigation.indexes
+    - content.code.copy
+    - content.action.edit
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+plugins:
+  - search
+
+# Links out of docs/ (examples/, Go sources, CONTRIBUTING.md) are correct on GitHub
+# and 404 here, so the hook rewrites those to the repository at build time.
+hooks:
+  - scripts/mkdocs_repo_links.py
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      # GitHub's own slugger, so an anchor written for a page read on GitHub is
+      # the same anchor here and #a--b (a dropped em dash) still resolves.
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+validation:
+  nav:
+    # A page absent from both nav and not_in_nav fails the build: publishing a
+    # page nothing navigates to is the mistake, not an omission.
+    omitted_files: warn
+    not_found: warn
+  links:
+    absolute_links: warn
+    unrecognized_links: warn
+    anchors: warn
+
+not_in_nav: |
+  API.md
+  ARCHITECTURE.md
+  MACOS_DISTRIBUTION.md
+  QUICKSTART.md
+  RDF_INTEROP.md
+  RELEASING.md
+  SPEC_COMPLIANCE.md
+  TRAINING_EXAMPLES.md
+
+nav:
+  - Documentation: README.md
+  - Guide:
+      - guide/README.md
+      - guide/01-install.md
+      - guide/02-first-model.md
+      - guide/03-command-line.md
+      - guide/04-repl.md
+      - guide/05-checking.md
+      - guide/06-behavior.md
+      - guide/07-saving-and-rdf.md
+      - guide/08-editors.md
+      - guide/09-python.md
+      - guide/10-troubleshooting.md
+  - Reference:
+      - reference/README.md
+      - CLI: reference/cli.md
+      - REPL commands: reference/repl-commands.md
+      - Environment variables: reference/environment.md
+      - Go API: reference/api.md
+      - Python API: reference/python-api.md
+      - RDF mapping: reference/rdf-mapping.md
+      - Grammar: reference/grammar/README.md
+  - Internals:
+      - internals/README.md
+      - Architecture: internals/architecture.md
+      - Testing: internals/testing.md
+      - Performance: internals/performance.md
+      - Design notes:
+          - internals/design/README.md
+          - internals/design/action-executor.md
+          - internals/design/orthogonal-regions.md
+          - internals/design/pseudostates.md
+          - internals/design/python-grpc-bindings.md
+          - internals/design/python-grpc-phase1-plan.md
+          - internals/design/python-grpc-phase2-plan.md
+          - internals/design/python-grpc-phase3-plan.md
+          - internals/design/python-grpc-phase3-fixes.md
+          - internals/design/python-grpc-phase4-plan.md
+      - Plans:
+          - internals/notes/README.md
+          - internals/notes/behavior-robustness-plan.md
+          - internals/notes/lowering-integration-plan.md
+          - internals/notes/parser-robustness-plan.md
+  - Project:
+      - project/README.md
+      - Spec compliance: project/spec-compliance.md
+      - Training examples: project/training-examples.md
+      - Roadmap: project/roadmap.md
+      - Releasing: project/releasing.md
+      - macOS distribution: project/macos-distribution.md
+      - OMG issues: project/omg-issues.md
+      - Demo: project/demo.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,9 +2,9 @@
 # GitHub, and MkDocs is only the renderer.
 site_name: OpenSysML
 site_description: A SysML v2 and KerML implementation in Go — language server, REPL, execution runtime, Python client
-site_url: https://jpl-devin.github.io/OpenSysML/
-repo_url: https://github.com/JPL-Devin/OpenSysML
-repo_name: JPL-Devin/OpenSysML
+site_url: https://open-mbee.github.io/OpenSysML/
+repo_url: https://github.com/Open-MBEE/OpenSysML
+repo_name: Open-MBEE/OpenSysML
 edit_uri: edit/main/docs/
 copyright: Apache-2.0
 

--- a/scripts/mkdocs_repo_links.py
+++ b/scripts/mkdocs_repo_links.py
@@ -13,7 +13,7 @@ log = logging.getLogger("mkdocs.hooks.repo_links")
 
 # Inline links and images; docs/ uses no reference-style links.
 LINK = re.compile(r"(!?\[[^\]]*\]\()([^)\s]+)((?:\s+\"[^\"]*\")?\))")
-FENCE = re.compile(r"^\s*(```+|~~~+)")
+FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
 SCHEME = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 
 
@@ -56,12 +56,20 @@ def on_page_markdown(markdown: str, page, config, files) -> str:
         target = _rewrite(match.group(2), page_dir, docs_dir, repo_root, repo_url)
         return f"{match.group(1)}{target}{match.group(3)}"
 
-    out, in_fence, fence = [], False, ""
+    out, fence = [], ""
     for line in markdown.splitlines(keepends=True):
         marker = FENCE.match(line)
-        if marker and (not in_fence or line.strip().startswith(fence)):
-            in_fence, fence = not in_fence, marker.group(1)
-            out.append(line)
-            continue
-        out.append(line if in_fence else LINK.sub(substitute, line))
+        if marker:
+            run, info = marker.group(1), marker.group(2).strip()
+            if not fence:
+                fence = run
+                out.append(line)
+                continue
+            # CommonMark: a closing fence is the same character, at least as long,
+            # and carries no info string — so ```markdown showing ```bash stays open.
+            if not info and run[0] == fence[0] and len(run) >= len(fence):
+                fence = ""
+                out.append(line)
+                continue
+        out.append(line if fence else LINK.sub(substitute, line))
     return "".join(out)

--- a/scripts/mkdocs_repo_links.py
+++ b/scripts/mkdocs_repo_links.py
@@ -1,0 +1,67 @@
+"""Rewrite links that leave docs/ so they resolve on the published site.
+
+A page's `../../examples/foo.sysml` is a real file on GitHub but has no page on the
+site, so it is rewritten to the repository here instead of being hard-coded in the
+page. Links inside docs/ are left as written, so MkDocs still validates them.
+"""
+
+import logging
+import re
+from pathlib import Path
+
+log = logging.getLogger("mkdocs.hooks.repo_links")
+
+# Inline links and images; docs/ uses no reference-style links.
+LINK = re.compile(r"(!?\[[^\]]*\]\()([^)\s]+)((?:\s+\"[^\"]*\")?\))")
+FENCE = re.compile(r"^\s*(```+|~~~+)")
+SCHEME = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
+
+def _rewrite(target: str, page_dir: Path, docs_dir: Path, repo_root: Path, repo_url: str) -> str:
+    if not target or target.startswith(("#", "/")) or SCHEME.match(target):
+        return target
+
+    path, _, fragment = target.partition("#")
+    if not path:
+        return target
+
+    resolved = (page_dir / path).resolve()
+    if resolved == docs_dir or docs_dir in resolved.parents:
+        # A directory is a listing on GitHub; here it means the section's index.
+        if resolved.is_dir() and (resolved / "README.md").is_file():
+            return f"{path.rstrip('/')}/README.md" + (f"#{fragment}" if fragment else "")
+        return target
+
+    try:
+        relative = resolved.relative_to(repo_root)
+    except ValueError:
+        log.warning("link %r in %s escapes the repository", target, page_dir)
+        return target
+
+    kind = "tree" if resolved.is_dir() else "blob"
+    url = f"{repo_url}/{kind}/main/{relative.as_posix()}"
+    return f"{url}#{fragment}" if fragment else url
+
+
+def on_page_markdown(markdown: str, page, config, files) -> str:
+    repo_url = (config.get("repo_url") or "").rstrip("/")
+    if not repo_url:
+        return markdown
+
+    repo_root = Path(config["config_file_path"]).resolve().parent
+    docs_dir = Path(config["docs_dir"]).resolve()
+    page_dir = (docs_dir / page.file.src_uri).resolve().parent
+
+    def substitute(match: re.Match) -> str:
+        target = _rewrite(match.group(2), page_dir, docs_dir, repo_root, repo_url)
+        return f"{match.group(1)}{target}{match.group(3)}"
+
+    out, in_fence, fence = [], False, ""
+    for line in markdown.splitlines(keepends=True):
+        marker = FENCE.match(line)
+        if marker and (not in_fence or line.strip().startswith(fence)):
+            in_fence, fence = not in_fence, marker.group(1)
+            out.append(line)
+            continue
+        out.append(line if in_fence else LINK.sub(substitute, line))
+    return "".join(out)


### PR DESCRIPTION
## Summary

Two changes: `docs/` is now published as a GitHub Pages site, and the ontology table generator no longer resolves `git` through `PATH` (the one vulnerability SonarCloud reports on this codebase, `go:S4036`).

**The generator's commit lookup.** `commitSHA` shelled out to record which ontology commit a generated table came from:

```go
-	cmd := exec.Command("git", "-C", root, "rev-parse", "HEAD")
```

Rather than pinning an absolute path, it now reads the checkout's plumbing directly — `.git/HEAD`, symbolic-ref resolution against loose refs, `packed-refs` as the fallback (the case that matters, since a fresh clone usually has no loose ref for the branch), raw-SHA detached HEAD, a `.git` *file* containing `gitdir:`, and worktree `commondir` for where refs live. That removes the finding at its root and drops the `git` binary dependency from a code generator. Failures return a `*gitMetadataError` naming the unreadable file, and the digest must be 40 or 64 lowercase hex (sha256 checkouts included) before it is returned — the generator prints `commit[:12]`, so a short value would otherwise be recorded in the table or panic the slice. `internal/core/rdf/ontology/table.go` is untouched and byte-identical: the recorded SHA does not change.

The five `#nosec G304` annotations are there because this repository's own gosec gate flags every dynamic-path `os.ReadFile`; the paths derive from the checkout the caller asked for, and refs are validated before being joined.

**`docs/` as a Pages site.** MkDocs renders the existing tree with no page moves, published from a `Pages` workflow gated on `github.repository == 'Open-MBEE/OpenSysML'` so a fork doesn't deploy the same pages under its own domain. Two things worth knowing:

- `mkdocs build --strict` also runs in the PR workflow, so a link or anchor left behind by a moved page fails the PR rather than publishing a 404 from `main`. New pages must be added to `nav:` in `mkdocs.yml` or they are published but unreachable.
- `scripts/mkdocs_repo_links.py` is an `on_page_markdown` hook for links that leave `docs/`: `../../examples/foo.sysml` is a real file on GitHub but has no page on the site, so it is rewritten to `<repo_url>/blob/main/...` at build time instead of being hard-coded per page. Links *inside* `docs/` are left alone so MkDocs still validates them, and a directory link becomes that section's `README.md`. The hook tracks fenced code blocks per CommonMark so link-looking text in an example isn't rewritten.

`make docs-install` once, then `make docs` builds it the way CI does and `make docs-serve` previews it.

Note on the CircleCI SonarCloud job: it has still never executed, because CircleCI does not build forked pull requests here. The merge commit of this PR is an ordinary branch push, so it should be the first run that proves the analysis exclusions and Go coverage actually take effect. Until a CircleCI scan is the source of truth, SonarCloud Automatic Analysis keeps overriding `sonar-project.properties` (it ignores that file), which is why the last analysis still counted the generated `table.go` in duplication and reported no coverage.

One repository setting this needs: GitHub Pages must be set to build from GitHub Actions (Settings → Pages → Source: GitHub Actions), or the `deploy` job fails on first run.
