### PR TITLE
fix(parser): allow a conditional expression in the then branch

### DIFF
--- a/internal/core/parser/calc_conditional_expr_test.go
+++ b/internal/core/parser/calc_conditional_expr_test.go
@@ -33,3 +33,19 @@ func TestCalcConditionalExpressionWithBodyCondition(t *testing.T) {
 		})
 	}
 }
+
+// Both '?' operands are owned expressions per KerMLExpressions.xtext.
+func TestCalcConditionalExpressionNestedInThenBranch(t *testing.T) {
+	bodies := []string{
+		"if n > 0 ? if n > 9 ? 9 else n else 0",
+		"if n > 0 ? if n > 9 ? 9 else n else if n < -9 ? -9 else n",
+	}
+	for _, body := range bodies {
+		src := "package P { calc def C { in n : Integer; " + body + " } }"
+		p := New(source.New("t.sysml", []byte(src)))
+		p.ParseFile()
+		if len(p.Diagnostics) != 0 {
+			t.Fatalf("parse diagnostics for %q: %v", body, p.Diagnostics)
+		}
+	}
+}

--- a/internal/core/parser/expr.go
+++ b/internal/core/parser/expr.go
@@ -17,7 +17,7 @@ func (p *Parser) parseConditional() ast.Node {
 		p.advance() // if
 		cond := p.parseBinary(precNullCoalesce)
 		p.expect(lexer.Question, "expected '?' in conditional")
-		thn := p.parseBinary(precNullCoalesce)
+		thn := p.parseConditional()
 		p.expect2Keyword("else")
 		els := p.parseConditional()
 		e := &ast.OperatorExpr{Operator: ast.OpConditional, Operands: []ast.Node{cond, thn, els}}


### PR DESCRIPTION
Fixes #73

`parseConditional` read the then branch with `parseBinary(precNullCoalesce)`, so an `if` nested there was consumed as an identifier and the parser reported `expected 'else'` on the next token. Nesting in the else branch already worked.

Per the pilot implementation's KerMLExpressions.xtext, both operands after `?` are `OwnedExpressionReference`, which derives back to `ConditionalExpression`; only the condition is restricted to `NullCoalescingExpression`. The then branch now recurses into `parseConditional`, with a regression test covering nesting in the then branch alone and combined with an `else if` chain