### PR TITLE
feat(lsp): render hover as Markdown when the client supports it

### DIFF
--- a/internal/lsp/files.go
+++ b/internal/lsp/files.go
@@ -25,6 +25,20 @@ func (s *Server) setFolders(folders []string) {
 	s.folders = folders
 }
 
+// setHoverMarkdown records whether the client renders Markdown hovers.
+func (s *Server) setHoverMarkdown(ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hoverMarkdown = ok
+}
+
+// wantsMarkdownHover reports whether hovers should be rendered as Markdown.
+func (s *Server) wantsMarkdownHover() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hoverMarkdown
+}
+
 // initializeFolders returns a session's folders, preferring workspaceFolders and
 // falling back to the deprecated rootUri/rootPath older clients send instead.
 func initializeFolders(params *protocol.InitializeParams) []string {

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -24,34 +24,65 @@ func (s *Server) Hover(ctx context.Context, params *protocol.HoverParams) (*prot
 		return nil, nil
 	}
 
-	var b strings.Builder
-	b.WriteString(sym.Kind.String())
+	signature := sym.Kind.String()
 	if sym.Name != "" {
-		b.WriteString(" ")
-		b.WriteString(sym.Name)
+		signature += " " + sym.Name
 	}
 	// A metadata body declaration implicitly redefines a feature of the
 	// annotation's metadata definition (KerML 7.4.7); name it and its type.
 	if isMetadataBodyScope(sym.OwnerScope) {
 		if target, fqn, ok := s.ws.MetadataBodyRedefines(sym); ok {
-			b.WriteString(" redefines ")
-			b.WriteString(fqn)
+			signature += " redefines " + fqn
 			if t := declaredTypeText(target); t != "" {
-				b.WriteString(" : ")
-				b.WriteString(t)
+				signature += " : " + t
 			}
 		}
 	}
-	if note := leadingDocText(content, sym.LeadingTrivia); note != "" {
-		b.WriteString("\n\n")
-		b.WriteString(note)
-	}
+	docText := leadingDocText(content, sym.LeadingTrivia)
 
 	rng := spanToRange(content, sym.DeclSpan)
 	return &protocol.Hover{
-		Contents: protocol.MarkupContent{Kind: protocol.PlainText, Value: b.String()},
+		Contents: s.hoverContents(signature, docText),
 		Range:    &rng,
 	}, nil
+}
+
+// hoverContents renders the hover as Markdown when the client supports it,
+// plain text otherwise.
+func (s *Server) hoverContents(signature, doc string) protocol.MarkupContent {
+	if s.wantsMarkdownHover() {
+		var b strings.Builder
+		b.WriteString("```sysml\n")
+		b.WriteString(signature)
+		b.WriteString("\n```")
+		if prose := docCommentProse(doc); prose != "" {
+			b.WriteString("\n\n")
+			b.WriteString(prose)
+		}
+		return protocol.MarkupContent{Kind: protocol.Markdown, Value: b.String()}
+	}
+
+	value := signature
+	if doc != "" {
+		value += "\n\n" + doc
+	}
+	return protocol.MarkupContent{Kind: protocol.PlainText, Value: value}
+}
+
+// docCommentProse strips the comment delimiters and per-line decoration from a
+// doc comment so it renders as Markdown prose rather than as source.
+func docCommentProse(doc string) string {
+	doc = strings.TrimSpace(doc)
+	doc = strings.TrimPrefix(doc, "/*")
+	doc = strings.TrimSuffix(doc, "*/")
+	var lines []string
+	for _, line := range strings.Split(doc, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "//")
+		line = strings.TrimPrefix(line, "*")
+		lines = append(lines, strings.TrimSpace(line))
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
 }
 
 // symbolAtOffset finds the innermost symbol whose DeclSpan contains offset.

--- a/internal/lsp/hover_test.go
+++ b/internal/lsp/hover_test.go
@@ -67,6 +67,85 @@ func TestHoverIncludesDocComment(t *testing.T) {
 	}
 }
 
+// initMarkdownHover initializes s as a client that renders Markdown hovers.
+func initMarkdownHover(t *testing.T, s *Server) {
+	t.Helper()
+	_, err := s.Initialize(context.Background(), &protocol.InitializeParams{
+		Capabilities: protocol.ClientCapabilities{
+			TextDocument: &protocol.TextDocumentClientCapabilities{
+				Hover: &protocol.HoverTextDocumentClientCapabilities{
+					ContentFormat: []protocol.MarkupKind{protocol.Markdown, protocol.PlainText},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Initialize err = %v", err)
+	}
+}
+
+func hoverInSrc(t *testing.T, s *Server, name, src string, off int) *protocol.Hover {
+	t.Helper()
+	res, err := s.Hover(context.Background(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri.File(name)},
+			Position:     offsetToPosition([]byte(src), off),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Hover err = %v", err)
+	}
+	if res == nil {
+		t.Fatal("Hover result = nil, want content")
+	}
+	return res
+}
+
+func TestHoverRendersMarkdownWhenClientSupportsIt(t *testing.T) {
+	ws := model.NewWorkspace()
+	s := NewServer(ws)
+	initMarkdownHover(t, s)
+	name := uri.File("/tmp/hm.sysml").Filename()
+	src := "package P {\n    doc /*\n     * A wheel.\n     */\n    part def Wheel;\n}\n"
+	ws.Open(name, []byte(src), 1)
+
+	res := hoverInSrc(t, s, name, src, strings.Index(src, "Wheel"))
+	if res.Contents.Kind != protocol.Markdown {
+		t.Errorf("hover kind = %q, want %q", res.Contents.Kind, protocol.Markdown)
+	}
+	if !strings.Contains(res.Contents.Value, "```sysml") {
+		t.Errorf("hover value = %q, want a fenced sysml block", res.Contents.Value)
+	}
+	if !strings.Contains(res.Contents.Value, "Wheel") {
+		t.Errorf("hover value = %q, want the signature", res.Contents.Value)
+	}
+	if !strings.Contains(res.Contents.Value, "A wheel.") {
+		t.Errorf("hover value = %q, want the doc text", res.Contents.Value)
+	}
+	for _, marker := range []string{"/*", "*/", " * "} {
+		if strings.Contains(res.Contents.Value, marker) {
+			t.Errorf("hover value = %q, still carries the comment marker %q", res.Contents.Value, marker)
+		}
+	}
+}
+
+func TestHoverFallsBackToPlainTextWithoutMarkdownCapability(t *testing.T) {
+	ws := model.NewWorkspace()
+	s := NewServer(ws)
+	// No initialize: a client that never advertised Markdown must get plaintext.
+	name := uri.File("/tmp/hp.sysml").Filename()
+	src := "package P { namespace N; }"
+	ws.Open(name, []byte(src), 1)
+
+	res := hoverInSrc(t, s, name, src, strings.Index(src, "N"))
+	if res.Contents.Kind != protocol.PlainText {
+		t.Errorf("hover kind = %q, want %q", res.Contents.Kind, protocol.PlainText)
+	}
+	if strings.Contains(res.Contents.Value, "```") {
+		t.Errorf("plaintext hover value = %q, should carry no Markdown fence", res.Contents.Value)
+	}
+}
+
 func TestHoverMissWhenNoSymbol(t *testing.T) {
 	ws := model.NewWorkspace()
 	s := NewServer(ws)

--- a/internal/lsp/lifecycle.go
+++ b/internal/lsp/lifecycle.go
@@ -13,6 +13,7 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 	s.setFolders(initializeFolders(params))
 	if params != nil {
 		s.applyConformanceSettings(params.InitializationOptions)
+		s.setHoverMarkdown(clientRendersMarkdownHover(params.Capabilities))
 	}
 	return &protocol.InitializeResult{
 		Capabilities: protocol.ServerCapabilities{
@@ -57,6 +58,20 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 			Version: "0.1.0",
 		},
 	}, nil
+}
+
+// clientRendersMarkdownHover reports whether the client advertised Markdown
+// among the content formats it accepts for hover.
+func clientRendersMarkdownHover(caps protocol.ClientCapabilities) bool {
+	if caps.TextDocument == nil || caps.TextDocument.Hover == nil {
+		return false
+	}
+	for _, format := range caps.TextDocument.Hover.ContentFormat {
+		if format == protocol.Markdown {
+			return true
+		}
+	}
+	return false
 }
 
 // Initialized indexes the session's folders, so cross-file names resolve without

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -46,6 +46,8 @@ type Server struct {
 	shutdownReceived bool
 	exitReceived     bool
 	folders          []string
+	// hoverMarkdown records that the client advertised Markdown for hover.
+	hoverMarkdown bool
 }
 
 // notifier sends a notification by method name, which a client connection does.


### PR DESCRIPTION
Fixes #75

The signature is rendered as a fenced sysml block and the doc comment as prose, with the delimiters and per-line decoration stripped. A client that does not advertise Markdown under `textDocument.hover.contentFormat` still gets plain text.