### PR TITLE
docs: add build, quality and package badges to the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,24 @@ Notable changes per release. Format follows [Keep a Changelog](https://keepachan
 versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Cutting a release
 is described in [docs/project/releasing.md](docs/project/releasing.md).
 
-## Unreleased
+## 0.4.1 — 2026-08-30
+
+Release 0.4.1 is about what the tools *say* about a model. Every surface that names a declaration —
+a rendering, the REPL's echo and search, a runtime diagnostic, LSP hover and completion — printed the
+classification the implementation keeps internally rather than the notation the file was written in,
+so a datatype read as an attribute and a KerML classifier grew a `def` it never had. The written form
+now has one source, and those surfaces all read from it; hover and completion documentation render as
+Markdown for a client that advertises it, and as plain text for one that does not.
+
+One import path moves: the public Go API is now `github.com/Open-MBEE/OpenSysML/client/opensysml`.
+The API itself is unchanged, but Go has no import alias, so **a Go consumer must edit the import
+line** — the one change in this release that a user has to make.
+
+Behind those, native document queries gain a compiled planning layer (planning only: nothing
+executes or renders yet), the Python and Rust clients move under `clients/` beside the Java and Node
+ones, and the SonarCloud gate is measuring the project it is meant to — every language's tests now
+count toward coverage, the Java sources are analyzed with types, and the bug and vulnerability
+backlog is empty.
 
 ### Changed
 
@@ -21,7 +38,40 @@ is described in [docs/project/releasing.md](docs/project/releasing.md).
   client library from. Go has no import alias, so this breaks every consumer's import path; update
   the import, nothing else. The API is unchanged and still ships with the core `v*` tags.
 
+- **The Python and Rust clients live under `clients/`**, beside the Java and Node ones, rather than
+  at the repository root. Every path that named them moves with them: the CI jobs and publish
+  pipelines, the changed-area filters, the Makefile targets, the buf output paths, the analysis
+  inclusions and the documentation. Neither published package changes name, version or contents.
+
+### Added
+
+- **Native document queries now have a compiled planning layer.** Query definitions specialize the
+  bundled `DocumentQueries::Query` vocabulary, retain typed parameter/result metadata and source
+  provenance, and may invoke other named queries with explicit named bindings. Planning produces an
+  immutable dependency-ordered program and reports malformed definitions, unknown operations, bad
+  bindings, positional query composition, and complete direct or indirect composition cycles as
+  typed validation diagnostics. Execution and document rendering are not part of this release.
+
+- **Hover renders as Markdown when the editor supports it**: the signature is a fenced `sysml`
+  block and the doc comment reads as prose. A client that does not advertise Markdown still gets
+  the plain text it did before.
+
 ### Fixed
+
+- **An element is named the way its notation writes it**, on every surface that names one — a view
+  rendering, the REPL's echo and search, a runtime diagnostic, and LSP hover and completion. These
+  printed the internal classification of a declaration instead, so a `datatype` read as an attribute
+  and a KerML classifier was given a `def` suffix it never had. A short name that is not a valid
+  identifier is quoted as the notation requires, and emphasis a doc comment was authored with
+  survives into the rendered documentation.
+
+- **Hover keeps what the file says.** Each leading comment's delimiters are stripped on its own, a
+  doc comment keeps the line breaks it was written with, a named relationship's prefix stays out of
+  its signature, and a relationship is named by the keyword its name follows.
+
+- **Both operands of `?` may be conditional expressions.** The parser accepted one only in the else
+  branch, though `KerMLExpressions.xtext` makes both owned expressions and limits only the condition
+  to a null-coalescing expression.
 
 - **The Connect server's shutdown no longer runs on an already-cancelled context.** It derived its
   30-second grace period from `context.Background()`, dropping the request context's values; it now
@@ -67,6 +117,9 @@ is described in [docs/project/releasing.md](docs/project/releasing.md).
 - **The header's Community Wiki link points at the wiki's landing page**, rather than at the wiki
   root, which lands on whatever page GitHub considers first.
 
+- **A deserialized `ModelException` cannot claim an unbounded diagnostic count**, so a hostile or
+  corrupt stream no longer has the Java client allocate for one.
+
 ### Project
 
 - **The SonarCloud bug and vulnerability backlog is cleared.** A sort compares by an explicit
@@ -75,6 +128,14 @@ is described in [docs/project/releasing.md](docs/project/releasing.md).
   VS Code extension's webview ignores a message from any other origin. `sonar-project.properties`
   states, with its reason, each rule whose subject in one file is a developer command's documented
   behavior.
+
+- **The maintainability findings behind it are cleared too**, across Go, Java, Python, Rust,
+  TypeScript and the shell scripts: parameter lists over seven entries became option structs,
+  switches over thirty cases dispatch through kind-scoped helpers or lookup tables, duplicated
+  literals are hoisted, and the coverage script validates that the profile path it is given stays
+  in the working tree and reports a symlink loop rather than a traceback. Behavior is unchanged
+  throughout; the generated Python gRPC stubs and the cognitive complexity of Go test files are
+  excluded from analysis, since neither is code a reviewer edits.
 
 ## 0.4.0 — 2026-08-28
 
@@ -136,13 +197,6 @@ against it.
   Integer. Arithmetic is unchanged: the stored value was never rounded.
 
 ### Added
-
-- **Native document queries now have a compiled planning layer.** Query definitions specialize the
-  bundled `DocumentQueries::Query` vocabulary, retain typed parameter/result metadata and source
-  provenance, and may invoke other named queries with explicit named bindings. Planning produces an
-  immutable dependency-ordered program and reports malformed definitions, unknown operations, bad
-  bindings, positional query composition, and complete direct or indirect composition cycles as
-  typed validation diagnostics. Execution and document rendering are not part of this release.
 
 - **A typed state usage inherits the content of the definition typing it.** The definition's
   substates, initial transition, entry/do/exit behaviors, transitions, deferred events and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Notable changes per release. Format follows [Keep a Changelog](https://keepachan
 versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Cutting a release
 is described in [docs/project/releasing.md](docs/project/releasing.md).
 
-## 0.4.1 — 2026-08-30
+## 0.5.0 — 2026-08-30
 
-Release 0.4.1 is about what the tools *say* about a model. Every surface that names a declaration —
+Release 0.5.0 is about what the tools *say* about a model. Every surface that names a declaration —
 a rendering, the REPL's echo and search, a runtime diagnostic, LSP hover and completion — printed the
 classification the implementation keeps internally rather than the notation the file was written in,
 so a datatype read as an attribute and a KerML classifier grew a `def` it never had. The written form
@@ -15,7 +15,8 @@ Markdown for a client that advertises it, and as plain text for one that does no
 
 One import path moves: the public Go API is now `github.com/Open-MBEE/OpenSysML/client/opensysml`.
 The API itself is unchanged, but Go has no import alias, so **a Go consumer must edit the import
-line** — the one change in this release that a user has to make.
+line** — the one change in this release that a user has to make, and why this is a minor rather
+than a patch.
 
 Behind those, native document queries gain a compiled planning layer (planning only: nothing
 executes or renders yet), the Python and Rust clients move under `clients/` beside the Java and Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Notable changes per release. Format follows [Keep a Changelog](https://keepachan
 versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Cutting a release
 is described in [docs/project/releasing.md](docs/project/releasing.md).
 
-## 0.5.0 — 2026-08-30
+## 0.4.1 — 2026-08-30
 
-Release 0.5.0 is about what the tools *say* about a model. Every surface that names a declaration —
+Release 0.4.1 is about what the tools *say* about a model. Every surface that names a declaration —
 a rendering, the REPL's echo and search, a runtime diagnostic, LSP hover and completion — printed the
 classification the implementation keeps internally rather than the notation the file was written in,
 so a datatype read as an attribute and a KerML classifier grew a `def` it never had. The written form
@@ -15,8 +15,8 @@ Markdown for a client that advertises it, and as plain text for one that does no
 
 One import path moves: the public Go API is now `github.com/Open-MBEE/OpenSysML/client/opensysml`.
 The API itself is unchanged, but Go has no import alias, so **a Go consumer must edit the import
-line** — the one change in this release that a user has to make, and why this is a minor rather
-than a patch.
+line** — the one change in this release that a user has to make. No model that validated under
+0.4.0 stops validating.
 
 Behind those, native document queries gain a compiled planning layer (planning only: nothing
 executes or renders yet), the Python and Rust clients move under `clients/` beside the Java and Node

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to OpenSysML
 
-Thank you for your interest in contributing to OpenSysML!
+Thank you for your interest in contributing to OpenSysML. This document describes how to set up a
+development environment, the standards a change is expected to meet, and how contributions are
+reviewed and released.
 
 ## Development Setup
 
@@ -185,7 +187,7 @@ test(semantics): add conformance checking test cases
 
 ### Versioning
 
-We use [Semantic Versioning](https://semver.org/):
+The project follows [Semantic Versioning](https://semver.org/):
 
 - **MAJOR** (v1.0.0 → v2.0.0): Breaking changes
 - **MINOR** (v0.1.0 → v0.2.0): New features (backward compatible)
@@ -283,7 +285,7 @@ When a change needs documenting:
 - **Extend the chapter that already covers the surface** rather than adding a page per feature —
   a new REPL command belongs in [reference/repl-commands.md](docs/reference/repl-commands.md) and
   the chapter that teaches the workflow, not in a new `MY_FEATURE.md`.
-- **Teach in the guide, enumerate in the reference.** Don't repeat a flag table in both; link.
+- **Explain in the guide, enumerate in the reference.** Do not repeat a flag table in both; link to it.
 - **Measured numbers have one home** (fixture, corpus and conversion counts live in
   [docs/project/](docs/project/)); elsewhere, link to it instead of restating a number that
   will drift. Three release-gate surfaces are the deliberate exception, because
@@ -344,7 +346,7 @@ See [ARCHITECTURE.md](docs/internals/architecture.md) for detailed design.
 - **GitHub Issues:** three forms, picked when you open one — a **tool bug** (OpenSysML does
   something other than what it documents), a **spec conformance gap** (it disagrees with SysML v2
   or KerML, so name the clause), or an **objection to a ruling** (the behavior is deliberate and
-  you are arguing the interpretation is wrong). Check
+  the report argues that the interpretation is wrong). Check
   [spec-compliance.md](docs/project/spec-compliance.md) and
   [omg-issues.md](docs/project/omg-issues.md) first: a known divergence is usually already a row
   there with the reasoning behind it.
@@ -365,4 +367,4 @@ By contributing, you agree that your contributions will be licensed under the sa
 
 ---
 
-**Thank you for contributing to OpenSysML!** 🚀
+**Thank you for contributing to OpenSysML.**

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -279,7 +279,7 @@ part only when followed by a digit, which prevents `1..2` from becoming one
 real token. Exponents are consumed only when they contain the required digits.
 
 When changing number syntax, test neighboring punctuation and incomplete
-forms, not just the accepted literal.
+forms, not only the accepted literal.
 
 ### Adding or changing a token
 
@@ -379,8 +379,8 @@ Parser findings have two channels:
   such as a reserved keyword used where an unrestricted name was required.
 
 Choose the channel based on whether downstream code has the intended tree.
-Do not turn an ill-formed partial parse into a warning just to let a conformance
-gate pass.
+Do not turn an ill-formed partial parse into a warning merely to let a
+conformance gate pass.
 
 Diagnostics should:
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
 # Open Source SysML v2 Implementation
 
-A SysML v2 and KerML 1.1 implementation in Go—providing language server, interactive REPL, execution runtime, an embeddable Go API, and Python, Node/TypeScript, Java and Rust client libraries. Spanning the lifecycle from authoring to execution, delivering the integrated tooling experience systems engineers expect from modern language ecosystems.
+OpenSysML is a SysML v2 and KerML 1.1 implementation in Go. It provides a language server, an
+interactive REPL, an execution runtime, an embeddable Go API, and Python, Node/TypeScript, Java
+and Rust client libraries, covering the lifecycle from authoring through execution with the
+integrated tooling systems engineers expect from a modern language ecosystem.
 
-What that is measured against, and what it is not, is in [spec compliance](docs/project/spec-compliance.md) and the [pilot differential](docs/project/pilot-differential.md): we compare every diagnostic against the pinned OMG pilot implementation over its own corpora, and we do not claim conformance certification.
+The basis for these claims, and their limits, are documented in
+[spec compliance](docs/project/spec-compliance.md) and the
+[pilot differential](docs/project/pilot-differential.md): every diagnostic is compared against the
+pinned OMG pilot implementation over that implementation's own corpora, and no conformance
+certification is claimed.
 
-## Quick Start
+## Quick start
 
-**Get started in 5 minutes:** [the guide](docs/guide/)
+**Introductory material:** [the guide](docs/guide/)
 
-**All documentation, searchable:** <https://opensysml.org/> — the same
-pages as [docs/](docs/), rendered from `main`.
+**Complete searchable documentation:** <https://opensysml.org/> — the same pages as
+[docs/](docs/), rendered from `main`.
 
 ### Install
 
@@ -39,17 +46,18 @@ make build
 > so a tarball downloaded *in a browser* carries `com.apple.quarantine` and Gatekeeper shows
 > "cannot be opened because the developer cannot be verified". Homebrew downloads with
 > `curl`, which never sets that attribute, so `brew install` avoids the prompt entirely.
-> Fallback if you download the tarball directly (`curl -fL ... opensysml-darwin-arm64.tar.gz`,
-> then `xattr -d com.apple.quarantine`): see
-> [the guide](docs/guide/01-install.md#macos-gatekeeper). Signing/notarization is the eventual
-> fix — [docs/project/macos-distribution.md](docs/project/macos-distribution.md).
+> When the tarball is downloaded directly (`curl -fL ... opensysml-darwin-arm64.tar.gz`, followed
+> by `xattr -d com.apple.quarantine`), see
+> [the guide](docs/guide/01-install.md#macos-gatekeeper). Signing and notarization are the
+> intended long-term resolution —
+> [docs/project/macos-distribution.md](docs/project/macos-distribution.md).
 >
 > Install by the **fully-qualified** name. Homebrew 6 requires third-party taps to be trusted
 > before their Ruby is loaded, and `brew install Open-MBEE/tap/opensysml` trusts just that
 > formula. `brew tap Open-MBEE/tap && brew install opensysml` needs
 > `brew trust --formula Open-MBEE/tap/opensysml` in between.
 
-### Try it
+### Examples
 
 **Interactive modeling:**
 ```bash
@@ -137,37 +145,39 @@ sysml> %advance 30
   Remaining events: 0
 ```
 
-**See [examples/repl-behavioral-demo.sysml](examples/repl-behavioral-demo.sysml) for comprehensive demos.**
+**Further demonstrations are available in
+[examples/repl-behavioral-demo.sysml](examples/repl-behavioral-demo.sysml).**
 
 ---
 
-## What is This?
+## Overview
 
-**Think Python/Rust/Go tooling, but for SysML v2:**
+The project provides the tooling familiar from the Python, Rust and Go ecosystems, applied to
+SysML v2:
 
 - **Language Server** — A standard LSP server (`sysml-lsp`) with live diagnostics, semantic hover, go-to-definition, find references, completion, workspace-wide symbol search, formatting, rename, semantic tokens and quick fixes. A VS Code extension with TextMate grammars for `.sysml` and `.kerml` ships in [editors/vscode](editors/vscode), and any editor with a generic LSP client can drive the server directly — [guide chapter 8](docs/guide/08-editors.md) walks through both. *Not yet:* the extension is built from source rather than published to a marketplace, and the server answers no semantic token delta requests or signature help.
-- **Interactive REPL** — Exploratory modeling environment: define models incrementally, evaluate expressions on-the-fly, instantiate parts, run calculations, inspect runtime state—like IPython/Jupyter for systems engineering.
-- **Constraint Solving** *(experimental)* — Beyond evaluating what holds of an object: an external SMT solver answers whether a constraint, requirement or satisfaction assertion *can* hold, which conditions conflict when it cannot, what values would satisfy it, which variants a model permits, and what optimizes an `analysis def`'s objectives. The solver is optional and discovered at runtime — [the REPL command reference](docs/reference/repl-commands.md) documents each command and [installing a solver](docs/guide/01-install.md#installing-a-solver-optional) how to get one.
-- **Execution Runtime** — Not just a validator: instantiate parts, evaluate constraints against concrete values, execute calc/analysis cases. Action/state executor infrastructure complete (activity fork/join parallelism, decision guards, hierarchical/orthogonal states, choice/junction pseudostates, TimeEvent/ChangeEvent/AcceptEvent, sourceless transitions). See [spec compliance](docs/project/spec-compliance.md) for measured behavioral coverage.
-- **Embeddable Go API** — `client/opensysml` is the public Go surface: parse, look up symbols, evaluate expressions and instantiate parts from Go code, answered in process by the engine your binary already links — no port, no child process, no serialization round trip — or over the Connect protocol against a service someone else runs. See [client/opensysml/README.md](client/opensysml/README.md).
+- **Interactive REPL** — An exploratory modeling environment: define models incrementally, evaluate expressions interactively, instantiate parts, run calculations and inspect runtime state, comparable to IPython or Jupyter for systems engineering.
+- **Constraint Solving** *(experimental)* — In addition to evaluating what holds of an object, an external SMT solver determines whether a constraint, requirement or satisfaction assertion *can* hold, which conditions conflict when it cannot, which values would satisfy it, which variants a model permits, and what optimizes an `analysis def`'s objectives. The solver is optional and discovered at runtime. [The REPL command reference](docs/reference/repl-commands.md) documents each command, and [installing a solver](docs/guide/01-install.md#installing-a-solver-optional) describes how to obtain one.
+- **Execution Runtime** — More than a validator: instantiate parts, evaluate constraints against concrete values and execute calc and analysis cases. Action and state executor infrastructure is complete (activity fork/join parallelism, decision guards, hierarchical/orthogonal states, choice/junction pseudostates, TimeEvent/ChangeEvent/AcceptEvent, sourceless transitions). See [spec compliance](docs/project/spec-compliance.md) for measured behavioral coverage.
+- **Embeddable Go API** — `client/opensysml` is the public Go surface: parse, look up symbols, evaluate expressions and instantiate parts from Go code, answered in process by the engine the calling binary already links (no port, no child process and no serialization round trip), or over the Connect protocol against an externally hosted service. See [client/opensysml/README.md](client/opensysml/README.md).
 - **Python Client Library** — gRPC-based Python bindings for programmatic access: parse models, resolve symbols, evaluate expressions, instantiate parts, execute actions/state machines. Includes IPython display hooks for Jupyter notebooks and pandas DataFrame integration. Constraint, requirement, satisfaction and calc verdicts are available as RPCs (`verify_constraint`, `verify_requirement`, `verify_satisfaction`, `calc`).
 - **Node/TypeScript Client Library** — `@opensysml/client` for Node and the browser, over the Connect protocol with protobuf bodies: parse, evaluate, look up symbols and instantiate, with values as discriminated unions. No native addon and nothing downloaded at install time ([clients/node/README.md](clients/node/README.md)).
 - **Java Client Library** — `io.github.open-mbee:opensysml-client` for a JVM host application it does not own, on the JDK's own `java.net.http.HttpClient`, so no gRPC, Netty or `tcnative` reaches the host ([clients/java/README.md](clients/java/README.md)).
 - **Rust Client Library** — A blocking client for the local `sysml-grpc` service, with no asynchronous runtime in its default dependency tree, available from the [Rust crate documentation](clients/rust/README.md).
 
-Which client to pick, what the four newer ones cover, and what they deliberately leave to a v2 is [docs/reference/clients.md](docs/reference/clients.md).
-- **Modern Toolchain** — Incremental compilation, bundled standard library, persistent semantic caches. A model is a set of files, named on the command line or opened by the editor.
+Guidance on selecting a client, the coverage of the four newer clients, and the functionality they intentionally defer to a future version is provided in [docs/reference/clients.md](docs/reference/clients.md).
+- **Modern Toolchain** — Incremental compilation, a bundled standard library and persistent semantic caches. A model is a set of files, named on the command line or opened by the editor.
 
 ## Goals
 
-- **Performance:** Sub-millisecond parsing, single static binary, no JVM/Eclipse runtime
-- **Completeness:** SysML v2 textual notation support (96/96 stdlib files parse clean: 94 vendored OMG files and 2 OpenSysML extensions)
-- **Executable models:** Instantiate, evaluate, simulate—turn specifications into running systems
-- **Real-world ergonomics:** Multi-file workspaces, incremental analysis, rich diagnostics
+- **Performance:** sub-millisecond parsing, a single static binary, and no JVM or Eclipse runtime
+- **Completeness:** SysML v2 textual notation support (96 of 96 standard library files parse cleanly: 94 vendored OMG files and 2 OpenSysML extensions)
+- **Executable models:** instantiate, evaluate and simulate, turning specifications into running systems
+- **Practical ergonomics:** multi-file workspaces, incremental analysis and detailed diagnostics
 
 ## Status
 
-**Active development. Core infrastructure operational:**
+The project is under active development, with the core infrastructure operational:
 
 | Component | Status |
 |-----------|--------|
@@ -196,7 +206,7 @@ Which client to pick, what the four newer ones cover, and what they deliberately
 | Public Go API (`client/opensysml`) | ✅ Complete for its v1 scope: parse, diagnostics, symbols, evaluation, instantiation and capability negotiation, answered in process or over Connect, with the edit API, conversion, verification, behaviour execution and Query out of scope ([client/opensysml/README.md](client/opensysml/README.md)) |
 | Python client library | ✅ Complete for the RPCs that exist (connection lifecycle, parse/symbols/eval/instantiate/execute, constraint/requirement/satisfaction/calc verification, conversion, edits, Query, IPython hooks, DataFrame) |
 | Rust client library | 🚧 Blocking v1 client for parse, diagnostics, symbols, evaluation and instantiation; see the [Rust client README](clients/rust/README.md) |
-| Java client library | ✅ Complete for its v1 scope, and honest about the rest: connection lifecycle, parse/symbols/eval/instantiate and capability negotiation, with the edit API, conversion, verification, behaviour execution and Query out of scope. Connect protocol over the JDK's own HTTP client, so no gRPC or Netty reaches a host application ([clients/java/README.md](clients/java/README.md)) |
+| Java client library | ✅ Complete for its v1 scope, with the remaining scope stated explicitly: connection lifecycle, parse/symbols/eval/instantiate and capability negotiation, with the edit API, conversion, verification, behaviour execution and Query out of scope. Connect protocol over the JDK's own HTTP client, so no gRPC or Netty reaches a host application ([clients/java/README.md](clients/java/README.md)) |
 | Node/TypeScript client library | ✅ Complete for the same v1 scope, in Node and the browser, over the Connect protocol with protobuf bodies and no native addon; values arrive as discriminated unions ([clients/node/README.md](clients/node/README.md)) |
 
 <!-- doc-counts:begin refereed-figures -->
@@ -221,7 +231,7 @@ What these numbers cannot show: the OMG corpora are demonstrations rather than a
 **Reference differential:** 357 files compared diagnostic-by-diagnostic against the pinned OMG pilot implementation (`2026-07`), 332 in full agreement; every divergence is enumerated and adjudicated in [the differential](docs/project/pilot-differential.md), reproducible with `go run ./cmd/pilot-diff`.
 **Rejection oracle:** the reverse direction — do we reject what the reference rejects? 120 hand-written invalid models validated by both implementations, 120 rejected by both, 0 the pinned pilot rejects and we accept; every permissiveness gap is enumerated with a reproducer and likely root cause in [the rejection oracle](docs/project/pilot-rejection.md), reproducible with `go run ./cmd/pilot-reject`. We wrote all 120 cases, so the count measures our coverage of the rejection surface, not our conformance — a sample, not a proof.
 **Training examples:** 100/100 files clean, gated by `internal/core/model/testdata/training_examples_expected.txt`. Download with `./scripts/download-training-examples.sh` (from the [OMG training directory](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/tree/master/sysml/src/training)). See [training examples](docs/project/training-examples.md) for analysis.
-**Semantic layer:** Complete implementation of runtime operators, feature chains, and validation rules. See [examples/semantic-layer/](examples/semantic-layer/) for comprehensive demo.
+**Semantic layer:** a complete implementation of runtime operators, feature chains and validation rules. See [examples/semantic-layer/](examples/semantic-layer/) for a full demonstration.
 
 ## Architecture
 
@@ -242,12 +252,12 @@ What these numbers cannot show: the OMG corpora are demonstrations rather than a
 ```
 
 **Key design principles:**
-- **Incremental & lazy:** Parse immediately, resolve semantics on-demand (gopls/rust-analyzer precedent)
-- **Immutable AST:** All semantic state lives in side tables keyed by node/symbol
-- **Pluggable validation:** Tiered passes (syntax → names → types → constraints)
-- **Separated concerns:** Static analysis pipeline feeds execution runtime
+- **Incremental and lazy:** parse immediately and resolve semantics on demand, following the precedent set by gopls and rust-analyzer
+- **Immutable AST:** all semantic state resides in side tables keyed by node or symbol
+- **Pluggable validation:** tiered passes (syntax → names → types → constraints)
+- **Separated concerns:** the static analysis pipeline feeds the execution runtime
 
-## Module Structure
+## Module structure
 
 ```
 github.com/Open-MBEE/OpenSysML
@@ -282,12 +292,12 @@ github.com/Open-MBEE/OpenSysML
 
 ## Technology
 
-- **Language:** Go 1.25+ (goroutines for concurrency, single static binary, proven LSP track record)
-- **Parser:** Hand-written recursive descent (zero overhead, full error recovery, sub-ms parses)
-- **Grammar source:** OMG pilot Xtext grammars (`SysML.xtext` + `KerMLExpressions`)
+- **Language:** Go 1.25 or later (goroutines for concurrency, a single static binary, and an established record in language servers)
+- **Parser:** hand-written recursive descent (no framework overhead, full error recovery, sub-millisecond parses)
+- **Grammar source:** OMG pilot Xtext grammars (`SysML.xtext` and `KerMLExpressions`)
 - **Spec compliance:** [OMG SysML v2.1 Beta 1 / KerML 1.1](https://www.omg.org/spec/SysML/2.0) (2026-07 release)
 - **Standard library:** 94 files from [SysML v2 Pilot Implementation 2026-07](https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation/releases/tag/2026-07), byte-identical, plus the non-normative `OpenSysML Libraries/OpenSysMLMathFunctions.kerml` extension
-- **CI/CD:** CircleCI for automated builds, tests, and releases
+- **CI/CD:** CircleCI for automated builds, tests and releases
 
 ## Releases
 
@@ -299,7 +309,7 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [Releases 
 - Windows (x64)
 
 **Release process:**
-- Every commit: Build + test
+- Every commit: build and test
 - Tagged releases (`v*`): the suite runs again on the tagged commit, then multi-platform
   binaries are published to GitHub Releases. Maintainer procedure:
   [docs/project/releasing.md](docs/project/releasing.md); what changed per release:
@@ -307,21 +317,21 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [Releases 
 - The Python client is released on its own tag (`opensysml-v*`), which uploads `opensysml` to
   PyPI — its version is not coupled to the core's, since it resolves a `sysml-grpc` binary
   at runtime from whichever release the caller names
-- The Java client is not published yet: `mvn -f clients/java/pom.xml install` is how to consume
-  it, and what a maintainer must obtain for a first Maven Central upload is in
+- The Java client is not yet published: consume it with `mvn -f clients/java/pom.xml install`. The
+  prerequisites a maintainer must obtain for a first Maven Central upload are listed in
   [docs/project/releasing.md](docs/project/releasing.md)
 - The Node client is released the same way on `client-node-v*`, which publishes
   `@opensysml/client` and the five per-platform packages that carry the service binary
-- The Rust client is not published to crates.io yet: use a path or Git dependency, and see
+- The Rust client is not yet published to crates.io: use a path or Git dependency, and see
   [clients/rust/README.md](clients/rust/README.md) and
-  [docs/project/releasing.md](docs/project/releasing.md) for what a first publish needs
-- `client/opensysml`, the public Go API, needs no release of its own — it is part of this module,
-  so `go get github.com/Open-MBEE/OpenSysML@v0.3.0` is how a Go program pins it
+  [docs/project/releasing.md](docs/project/releasing.md) for the requirements of a first publish
+- `client/opensysml`, the public Go API, requires no release of its own. It is part of this
+  module, so a Go program pins it with `go get github.com/Open-MBEE/OpenSysML@v0.3.0`
 
 **Release artifacts:** per-binary archives (`sysml-<os>-<arch>.tar.gz`,
 `sysml-lsp-<os>-<arch>.tar.gz`), `opensysml-<os>-<arch>.tar.gz` bundles containing both
 binaries, and `SHA256SUMS.txt`. macOS binaries are not Developer ID signed or notarized and
-Windows binaries are not Authenticode signed — see
+Windows binaries are not Authenticode signed; see
 [docs/project/macos-distribution.md](docs/project/macos-distribution.md).
 
 ## Building
@@ -343,9 +353,9 @@ go build -o bin/sysml ./cmd/sysml
 go build -o bin/sysml-grpc ./cmd/sysml-grpc
 ```
 
-## Python Client
+## Python client
 
-**opensysml** provides a Python client library for programmatic access to OpenSysML's parsing and runtime capabilities via gRPC.
+**opensysml** is a Python client library providing programmatic access to OpenSysML's parsing and runtime capabilities over gRPC.
 
 **Installation:**
 ```bash
@@ -374,16 +384,17 @@ print(instance.slots["mass"])
 **Features:**
 - Jupyter notebook integration with rich HTML displays
 - pandas DataFrame integration for model analysis
-- Automatic service lifecycle management
-- Full runtime API access (eval, instantiate, execute actions/states)
+- automatic service lifecycle management
+- full runtime API access (evaluation, instantiation, action and state execution)
 
-See [clients/python/INSTALL.md](clients/python/INSTALL.md) for detailed installation and usage instructions.
+Detailed installation and usage instructions are in
+[clients/python/INSTALL.md](clients/python/INSTALL.md).
 
-## Node/TypeScript Client
+## Node/TypeScript client
 
-**@opensysml/client** is the same access over the Connect protocol, for Node and
-the browser. It has no native addon: an install is a normal registry fetch, and
-the service binary comes from a per-platform optional dependency.
+**@opensysml/client** provides the same access over the Connect protocol, for Node and the
+browser. It includes no native addon: installation is a standard registry fetch, and the service
+binary is supplied by a per-platform optional dependency.
 
 ```ts
 import { loads } from "@opensysml/client";
@@ -392,22 +403,22 @@ await using model = await loads("part def Wheel { attribute radius : ScalarValue
 const radius = await model.eval("0.3 * 2");
 ```
 
-v1 covers loading, evaluation, symbol lookup and instantiation, and negotiates on
-the capabilities the service advertises. It is not published yet — see
-[clients/node/README.md](clients/node/README.md) for the API, the two lifecycle
-modes (a private child of the calling process, or a service someone else runs),
-what the browser entry point can and cannot do, and what v1 leaves out.
+Version 1 covers loading, evaluation, symbol lookup and instantiation, and negotiates against the
+capabilities the service advertises. It is not yet published. See
+[clients/node/README.md](clients/node/README.md) for the API, the two lifecycle modes (a private
+child of the calling process, or an externally hosted service), the capabilities and limitations
+of the browser entry point, and the functionality version 1 omits.
 
 ## Documentation
 
 - **[The guide](docs/guide/)** — install, first model, CLI, REPL, checks, behavior, saving, editors, Python
-- **[Client libraries](docs/reference/clients.md)** — the Go, Python, Node, Java and Rust surfaces, and which to pick
+- **[Client libraries](docs/reference/clients.md)** — the Go, Python, Node, Java and Rust surfaces, and how to choose between them
 - **[Reference](docs/reference/)** — CLI flags, REPL commands, environment, the Go and Python APIs, service transports, RDF mapping
 - **[Internals](docs/internals/architecture.md)** — the pipeline, the tiers, testing and performance
-- **[Project status](docs/project/spec-compliance.md)** — spec compliance, roadmap, releasing
-- **[Examples](examples/)** — Runtime demos and behavioral model examples
+- **[Project status](docs/project/spec-compliance.md)** — spec compliance, roadmap and releasing
+- **[Examples](examples/)** — runtime demonstrations and behavioral model examples
 
-The full map is [docs/README.md](docs/README.md).
+A complete index is available in [docs/README.md](docs/README.md).
 
 ## License
 
@@ -415,7 +426,7 @@ Apache 2.0
 
 ## Contributing
 
-Project currently in active development. See [CONTRIBUTING.md](CONTRIBUTING.md) for build, test, and contribution guidelines.
+The project is under active development. See [CONTRIBUTING.md](CONTRIBUTING.md) for build, test and contribution guidelines.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Open Source SysML v2 Implementation
 
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/Open-MBEE/OpenSysML/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/Open-MBEE/OpenSysML/tree/main)
+[![Quality gate](https://sonarcloud.io/api/project_badges/measure?project=Open-MBEE_OpenSysML&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Open-MBEE_OpenSysML)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Open-MBEE_OpenSysML&metric=coverage)](https://sonarcloud.io/component_measures?id=Open-MBEE_OpenSysML&metric=coverage)
+[![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=Open-MBEE_OpenSysML&metric=sqale_rating)](https://sonarcloud.io/component_measures?id=Open-MBEE_OpenSysML&metric=Maintainability)
+[![Reliability](https://sonarcloud.io/api/project_badges/measure?project=Open-MBEE_OpenSysML&metric=reliability_rating)](https://sonarcloud.io/component_measures?id=Open-MBEE_OpenSysML&metric=Reliability)
+[![Security](https://sonarcloud.io/api/project_badges/measure?project=Open-MBEE_OpenSysML&metric=security_rating)](https://sonarcloud.io/component_measures?id=Open-MBEE_OpenSysML&metric=Security)
+
+[![Release](https://img.shields.io/github/v/release/Open-MBEE/OpenSysML?label=release)](https://github.com/Open-MBEE/OpenSysML/releases/latest)
+[![Go reference](https://pkg.go.dev/badge/github.com/Open-MBEE/OpenSysML.svg)](https://pkg.go.dev/github.com/Open-MBEE/OpenSysML)
+[![PyPI](https://img.shields.io/pypi/v/opensysml?label=pypi)](https://pypi.org/project/opensysml/)
+[![Python versions](https://img.shields.io/pypi/pyversions/opensysml)](https://pypi.org/project/opensysml/)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+[![Documentation](https://img.shields.io/badge/docs-opensysml.org-blue)](https://opensysml.org/)
+
 A SysML v2 and KerML 1.1 implementation in Go—providing language server, interactive REPL, execution runtime, an embeddable Go API, and Python, Node/TypeScript, Java and Rust client libraries. Spanning the lifecycle from authoring to execution, delivering the integrated tooling experience systems engineers expect from modern language ecosystems.
 
 What that is measured against, and what it is not, is in [spec compliance](docs/project/spec-compliance.md) and the [pilot differential](docs/project/pilot-differential.md): we compare every diagnostic against the pinned OMG pilot implementation over its own corpora, and we do not claim conformance certification.

--- a/client/opensysml/README.md
+++ b/client/opensysml/README.md
@@ -2,7 +2,7 @@
 
 `github.com/Open-MBEE/OpenSysML/client/opensysml` is the Go surface of OpenSysML:
 parse SysML v2 models, look up symbols, evaluate expressions and instantiate
-parts, from Go code, with the engine that is already linked into your binary.
+parts, from Go code, using the engine already linked into the calling binary.
 
 ```go
 client, err := opensysml.New()
@@ -25,8 +25,8 @@ parse cache and model hashes, the same capability list, the same in-band
 failures, the same runtime budgets (read from the environment, as the service
 reads them).
 
-`Dial` is for the service you did not start: a shared long-lived `sysml-grpc`
-someone else runs, addressed explicitly (`"host:50051"` or
+`Dial` addresses a service the caller did not start: a shared, long-lived
+`sysml-grpc` run elsewhere, addressed explicitly (`"host:50051"` or
 `"https://sysml.example.com"`). It speaks the Connect protocol with protobuf
 bodies by default — JSON (`WithJSONBody`) costs an order of magnitude in
 encoding time on large responses and is a debugging affordance, per

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -37,8 +37,8 @@ model.edit().add_part("Vehicle", "engine", type="Engine").apply()
 
 Use `opensysml.loads(text, language="kerml")` for inline KerML content.
 
-Every call goes through the `sysml-grpc` service, which `opensysml` starts for you from
-`~/.opensysml/bin/sysml-grpc`; the guide below says how to put it there.
+Every call goes through the `sysml-grpc` service, which `opensysml` starts automatically from
+`~/.opensysml/bin/sysml-grpc`; the guide below describes how to install it there.
 
 ## Service ownership
 
@@ -207,7 +207,7 @@ model.eval("mass", subject="Demo::sedan")            # a method shadows nothing
 ```
 
 ```python
-from opensysml import eval          # shadows the builtin in this module — don't
+from opensysml import eval          # shadows the builtin in this module — avoid
 ```
 
 Guidance for this package and for code around it:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,45 +1,47 @@
 # OpenSysML documentation
 
-## Using it
+## Using OpenSysML
 
-**[The guide](guide/)** — a handbook, in reading order: [install](guide/01-install.md),
+**[The guide](guide/)** — a handbook, presented in reading order: [install](guide/01-install.md),
 [your first model](guide/02-first-model.md), [the command line](guide/03-command-line.md),
 [the REPL](guide/04-repl.md), [checks](guide/05-checking.md), [behavior](guide/06-behavior.md),
 [saving and RDF](guide/07-saving-and-rdf.md), [editors](guide/08-editors.md),
 [Python](guide/09-python.md), [troubleshooting](guide/10-troubleshooting.md).
 
-Runnable models are in [examples/](../examples/), with a catalog of what each one shows.
+Runnable models are provided in [examples/](../examples/), together with a catalog describing what
+each one demonstrates.
 
-## Looking one thing up
+## Reference
 
 - **[CLI](reference/cli.md)** — every flag of `sysml`, the modes, and the exit status
 - **[REPL commands](reference/repl-commands.md)** — every `%` command and its arguments
 - **[LSP extensions](reference/lsp.md)** — the custom render requests `sysml-lsp` serves a diagram client
-- **[Environment variables](reference/environment.md)** — the bounds one run may spend, and paths
-- **[Client libraries](reference/clients.md)** — the Go, Python, Node, Java and Rust surfaces, and which to pick
+- **[Environment variables](reference/environment.md)** — the bounds a single run may consume, and paths
+- **[Client libraries](reference/clients.md)** — the Go, Python, Node, Java and Rust surfaces, and how to choose between them
 - **[Go packages](reference/api.md)** — `client/opensysml` and the packages behind it, type by type
 - **[Python API](reference/python-api.md)** — `opensysml`, its generated typed classes and latency
-- **[Service transports](reference/service-transports.md)** — what `sysml-grpc` serves on one port, and what an absent capability does
-- **[RDF mapping](reference/rdf-mapping.md)** — which triples a model becomes, what is not mapped, and why the mapping is experimental
+- **[Service transports](reference/service-transports.md)** — what `sysml-grpc` serves on a single port, and the behavior of an absent capability
+- **[RDF mapping](reference/rdf-mapping.md)** — the triples a model becomes, the constructs that are not mapped, and why the mapping is experimental
 - **[Grammar](reference/grammar/README.md)** — grammar production → parser implementation
 
-## How it works
+## Internals
 
-- **[Architecture](internals/architecture.md)** — the pipeline, the tiers, the test contracts
+- **[Architecture](internals/architecture.md)** — the pipeline, the tiers and the test contracts
 - **[Testing](internals/testing.md)** — the test contracts each kind of change must satisfy
-- **[Performance](internals/performance.md)** — profiling, and what a large model costs
-- **[Design notes](internals/design/)** and **[plans](internals/notes/)** — for maintainers
+- **[Performance](internals/performance.md)** — profiling, and the cost of a large model
+- **[Design notes](internals/design/)** and **[plans](internals/notes/)** — maintainer material
 
-## Where the project stands
+## Project status
 
-- **[Spec compliance](project/spec-compliance.md)** — faithful, approximate, or not implemented
+- **[Spec compliance](project/spec-compliance.md)** — faithful, approximate or not implemented
 - **[Training examples](project/training-examples.md)** — the OMG corpus, 100/100 clean
-- **[Pilot corpora gate](project/pilot-corpora.md)** — our diagnostics on the three pinned OMG pilot corpora, ratcheted in CI
-- **[Pilot differential](project/pilot-differential.md)** — our diagnostics against the OMG pilot implementation
-- **[Grammar coverage](project/grammar-coverage.md)** — which OMG grammar productions our inputs exercise
-- **[Roadmap](project/roadmap.md)** — the known gaps, in the order they should be picked up
-- **[Releasing](project/releasing.md)** — the pre-tag gate, tagging, artifacts, Homebrew
+- **[Pilot corpora gate](project/pilot-corpora.md)** — OpenSysML diagnostics on the three pinned OMG pilot corpora, ratcheted in CI
+- **[Pilot differential](project/pilot-differential.md)** — OpenSysML diagnostics compared against the OMG pilot implementation
+- **[Grammar coverage](project/grammar-coverage.md)** — the OMG grammar productions the project's inputs exercise
+- **[Roadmap](project/roadmap.md)** — the known gaps, in the order they should be addressed
+- **[Releasing](project/releasing.md)** — the pre-tag gate, tagging, artifacts and Homebrew
 - **[macOS distribution](project/macos-distribution.md)** — Gatekeeper and the signing decision
-- **[Demo](project/demo.md)** — a scripted walkthrough of the whole surface
+- **[Demo](project/demo.md)** — a scripted walkthrough of the full surface
 
-Contributing, including where a new page belongs, is [CONTRIBUTING.md](../CONTRIBUTING.md).
+Contribution guidance, including where a new page belongs, is in
+[CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/guide/01-install.md
+++ b/docs/guide/01-install.md
@@ -1,7 +1,7 @@
 # 1. Install
 
-Install `sysml`, `sysml-lsp` and `sysml-grpc`, and verify what you installed. Nothing later in
-this guide needs anything else on the machine.
+This chapter covers installing `sysml`, `sysml-lsp` and `sysml-grpc` and verifying the
+installation. No other software is required for the remainder of this guide.
 
 ## From a release build (recommended)
 
@@ -82,14 +82,14 @@ Ways to avoid it, best first:
    go install github.com/Open-MBEE/OpenSysML/cmd/sysml@latest
    go install github.com/Open-MBEE/OpenSysML/cmd/sysml-lsp@latest
    ```
-4. **Clear the attribute** if you already downloaded the archive in a browser. Verify the
-   checksum first — you are turning off a security check, so make sure you have the file we
-   published:
+4. **Clear the attribute** if the archive was already downloaded in a browser. Verify the
+   checksum first, because clearing the attribute disables a security check and the file must
+   be confirmed as the published one:
    ```bash
    shasum -a 256 opensysml-darwin-arm64.tar.gz   # compare against SHA256SUMS.txt
    xattr -d com.apple.quarantine /usr/local/bin/sysml /usr/local/bin/sysml-lsp
    ```
-   `xattr -d: No such xattr` simply means the file was not quarantined. Use
+   `xattr -d: No such xattr` indicates that the file was not quarantined. Use
    `xattr -c <file>` to clear all attributes, or `xattr -dr com.apple.quarantine <dir>` for a
    directory.
 
@@ -107,7 +107,7 @@ holds of an object (see [reference/repl-commands.md](../reference/repl-commands.
 The solver is a separate program, run as a process and spoken to in SMT-LIB2 — nothing is
 linked in and nothing is bundled in the release archives, which stay single static binaries.
 Either [z3](https://github.com/Z3Prover/z3) (MIT) or [cvc5](https://github.com/cvc5/cvc5)
-works; z3 is the one to install unless you have a reason to prefer cvc5.
+works; install z3 unless there is a specific reason to prefer cvc5.
 
 **macOS and Linux, Homebrew — automatic:** z3 is a dependency of the formula, so the
 recommended install already brings a working `%check`:
@@ -128,10 +128,10 @@ sudo pacman -S z3            # Arch (extra/z3)
 sudo apk add z3              # Alpine (community repository)
 nix-shell -p z3              # nixpkgs, for one shell; or: nix profile install nixpkgs#z3
 ```
-Of these, apt is the one run while writing this; the rest were read off their package indexes
-(Fedora's `z3`, `extra/z3`, Alpine `community/z3`, and nixpkgs' `z3`, all shipping a `z3`
-program), so a distribution that has renamed or dropped the package is the case to expect
-trouble from.
+Only the apt command above was executed during testing; the others were taken from the
+corresponding package indexes (Fedora's `z3`, `extra/z3`, Alpine's `community/z3` and nixpkgs'
+`z3`, each of which ships a `z3` program). A distribution that has since renamed or dropped the
+package is the most likely source of difficulty.
 
 **Windows:** take the official prebuilt archive from
 [z3's releases](https://github.com/Z3Prover/z3/releases) — `z3-<version>-x64-win.zip` (for
@@ -140,8 +140,8 @@ either add the archive's `bin` directory to `PATH`, or point `OPENSYSML_SMT` at 
 ```powershell
 $env:OPENSYSML_SMT = "C:\tools\z3-5.1.0-x64-win\bin\z3.exe"
 ```
-[Scoop](https://scoop.sh) packages the same archive, so `scoop install z3` puts `z3.exe` on
-`PATH` for you.
+[Scoop](https://scoop.sh) packages the same archive, so `scoop install z3` places `z3.exe` on
+`PATH` automatically.
 
 **Any platform with Python — the `pip` fallback:** the `z3-solver` wheels (MIT) are published
 for Linux, macOS and Windows and carry the executable, not just the Python module:
@@ -160,8 +160,9 @@ take a prebuilt archive from [cvc5's releases](https://github.com/cvc5/cvc5/rele
 (`cvc5-Linux-x86_64-static.zip`, `cvc5-macOS-arm64-static.zip`, `cvc5-Win64-x86_64-static.zip`
 and so on), whose `bin/cvc5` is what goes on `PATH`. cvc5 is under a modified BSD licence, but
 its default build links GMP under LGPL-3, and it can be configured against GPL libraries (the
-`*-gpl` archives are those builds). That matters if you **redistribute** cvc5; it does not
-change how you may use OpenSysML, which links neither solver.
+`*-gpl` archives are those builds). Those terms apply to the **redistribution** of cvc5; they
+do not affect the terms under which OpenSysML may be used, because OpenSysML links neither
+solver.
 
 ### Solver compatibility — pointing the driver at another solver
 
@@ -183,10 +184,10 @@ scripts use:
 | Objective optimization | `(maximize …)`/`(minimize …)`, for `%optimize` | yes | **no** — parse error |
 | Objective priority | `:opt.priority`, a z3 extension | yes | **no** — answers `unsupported` |
 
-The two columns are what each solver answered when probed on this machine, not what its
-documentation claims. The last two rows are the only part of the subset cvc5 lacks, and
-`%optimize` is the only command that needs them: on cvc5 it refuses by naming the extension
-the solver lacks, and every other command works on either solver.
+The two columns record what each solver answered when probed on the test machine rather than
+what its documentation states. The last two rows are the only part of the subset that cvc5
+lacks, and `%optimize` is the only command that requires them: on cvc5 it declines and names
+the missing extension. Every other command works on either solver.
 
 Every logic a script sets other than that non-standard `ALL` is a standard SMT-LIB 2.6 one
 ([the logic list](https://smt-lib.org/logics.shtml)): `QF_UF`, `QF_LIA`, `QF_NIA`, `QF_LRA`,
@@ -205,14 +206,14 @@ SMT-LIB 2.6 unsat cores: `:produce-unsat-cores` with `:named` assertions and `(g
 install a solver that supports it or set OPENSYSML_SMT to one
 ```
 
-Which is distinct from the other two ways a solver run ends without a verdict: a solver that
-crashes, exits, or answers unreadably is a solver *process* error naming the stage it failed at,
-and a solver that answers but does not decide is the verdict `unknown` with the reason it gave.
-No verdict is ever invented from any of the three.
+This case is distinct from the other two ways a solver run can end without a verdict. A solver
+that crashes, exits or answers unreadably produces a solver *process* error naming the stage at
+which it failed, and a solver that answers without deciding produces the verdict `unknown`
+together with the reason it reported. In none of these cases is a verdict inferred.
 
-To check a solver of your own end to end, run the portability harness against it — it reports
-each feature as `pass`, `refuse` (the backend lacks it and said so) or `fail` (a script it
-rejected, which is a bug to report):
+To validate another solver end to end, run the portability harness against it. The harness
+reports each feature as `pass`, `refuse` (the backend reported the feature as unsupported) or
+`fail` (the backend rejected a script, which should be reported as a bug):
 
 ```bash
 OPENSYSML_SMT=/path/to/mysolver go test ./internal/core/solve -run TestPortability -v

--- a/docs/guide/02-first-model.md
+++ b/docs/guide/02-first-model.md
@@ -1,8 +1,8 @@
 # 2. Your first model
 
-Declare a part, give it values, instantiate it and look inside — first by typing at the prompt,
-then from a file. Everything here is notation you would write in a `.sysml` file; the REPL is
-just a faster way to see it answer.
+This chapter declares a part, gives it values, instantiates it and inspects the result, first
+at the interactive prompt and then from a file. Every construct shown is the same notation a
+`.sysml` file contains; the REPL reports the result more quickly.
 
 ## At the prompt
 
@@ -16,8 +16,8 @@ sysml>
 
 ### Define a Simple Part
 
-Library types such as `Real` are not in scope automatically — import them, exactly as a
-`.sysml` file would:
+Library types such as `Real` are not in scope automatically. Import them exactly as a `.sysml`
+file would:
 
 ```sysml
 sysml> private import ScalarValues::*;
@@ -30,17 +30,16 @@ sysml> part def Wheel {
 ✓ part def Wheel
 ```
 
-Each accepted declaration is echoed back as `✓ <kind> <name>`. A brace opens a
-continuation (`...>`) that runs to the matching one — but a **blank line ends the
-submission**, so leave none inside a declaration you are typing.
+Each accepted declaration is echoed back as `✓ <kind> <name>`. An opening brace begins a
+continuation (`...>`) that runs to the matching closing brace. A **blank line ends the
+submission**, so a declaration being typed must not contain one.
 
-Re-typing a namespace **adds to** the one already in the session, so
-`package P { part def B; }` after `package P { part def A; }` leaves both
-declared; an empty body (`package P { }`) is how you clear one. Anything a
-submission does drop is reported as a `note:` line — the members it no longer
-declares, the instances it invalidated (their IDs restart with the new model),
-and any `%action`/`%state` debugging session it ended. A debugging session over a
-declaration the submission did not touch keeps running.
+Re-typing a namespace **adds to** the one already in the session: `package P { part def B; }`
+submitted after `package P { part def A; }` leaves both declared. An empty body
+(`package P { }`) clears the namespace. Anything a submission drops is reported on a `note:`
+line: the members it no longer declares, the instances it invalidated (whose IDs restart with
+the new model), and any `%action` or `%state` debugging session it ended. A debugging session
+over a declaration the submission did not touch continues to run.
 
 ### Define a Vehicle
 
@@ -112,8 +111,8 @@ package MyModel {
 }
 ```
 
-Load it in the REPL. `%load` submits the file's contents as if you had typed them, so it
-reports the same `✓` lines; `%list` echoes everything the session currently holds:
+Load the file in the REPL. `%load` submits the file's contents as though they had been typed,
+so it reports the same `✓` lines. `%list` echoes everything the session currently holds:
 
 ```bash
 $ sysml
@@ -153,5 +152,5 @@ A composite feature lists the features of each of its objects under it, in order
 
 ---
 
-Next: [3. From the command line](03-command-line.md), which runs these same checks without a
-prompt. The prompt itself is covered in [4. The REPL](04-repl.md).
+Next: [3. From the command line](03-command-line.md), which performs these same checks without
+a prompt. The prompt itself is covered in [4. The REPL](04-repl.md).

--- a/docs/guide/03-command-line.md
+++ b/docs/guide/03-command-line.md
@@ -1,11 +1,11 @@
 # 3. From the command line
 
-Every check the REPL performs is also a flag, so a model can be checked from a script, a
-Makefile or a CI job. This chapter is the narrative; every flag and exit status is tabulated in
+Every check the REPL performs is also available as a command-line flag, so a model can be
+checked from a script, a Makefile or a continuous integration job without a prompt. This
+chapter explains the workflow; every flag and exit status is tabulated in
 [reference/cli.md](../reference/cli.md).
 
-The same checks the REPL runs are available as flags, so a model can be checked
-from a script or a build step without a prompt. Take `checks.sysml`:
+The examples below use the following model, `checks.sysml`:
 
 ```sysml
 package MyModel {
@@ -64,8 +64,8 @@ package MyModel {
 }
 ```
 
-Each flag may be repeated, and `-instantiate` runs first — whatever order the
-flags are written in — so the verdicts after it are about that object:
+Each flag may be repeated. `-instantiate` always runs first, regardless of the order in which
+the flags are written, so the verdicts that follow apply to the created object:
 
 ```bash
 $ sysml -instantiate MyModel::cold -constraint MyModel::cold::inRange checks.sysml
@@ -88,16 +88,16 @@ one constraint or requirement by name, every satisfaction assertion the model
 states, a calculation, an action, a state machine, and `-json` for a machine-readable
 report.
 
-The exit status is what a build step gates on, and it is the same on every run
-that is not a prompt — an evaluation, a conversion, a plain load — not only on a
-check: `0` when what was asked for was done, `1` when the model answered false,
-`2` when nothing was decided. The whole contract is in
+Build steps gate on the exit status, which is identical for every non-interactive run — an
+evaluation, a conversion or a plain load, not only a check: `0` when the requested operation
+succeeded, `1` when the model answered false, and `2` when nothing was decided. The full
+contract is documented in
 [reference/cli.md § Exit status](../reference/cli.md#exit-status).
 
-Status 2 is kept apart from 1 because an undecided check is not evidence against
-the model — treat it as a broken check, not a failing one. A condition that
-evaluated to false is the model's own answer; a name that does not resolve, or a
-condition over a feature with no value, is not:
+Status 2 is distinguished from status 1 because an undecided check is not evidence against the
+model and should be treated as a broken check rather than a failing one. A condition that
+evaluates to false is the model's own answer; an unresolved name, or a condition over a feature
+with no value, is not:
 
 ```bash
 $ sysml -constraint MyModel::hot::inRange -instantiate MyModel::hot checks.sysml; echo "exit=$?"
@@ -121,21 +121,21 @@ $ sysml -requirement MyModel::healthy checks.sysml; echo "exit=$?"
 exit=2
 ```
 
-That last case is the shape of a requirement with a `subject`: nothing binds the
-subject, so it has no object to be about. Write the intended pair into the model
-as `assert satisfy healthy by hot;` and check it with `-satisfy`, which creates
-the subject itself — `-requirement` decides a requirement whose conditions stand
-on their own, or one carried by a part an `-instantiate` created.
+The last case above shows a requirement that declares a `subject`: nothing binds the subject,
+so the requirement has no object to evaluate against. Declare the intended pairing in the model
+as `assert satisfy healthy by hot;` and check it with `-satisfy`, which creates the subject
+itself. `-requirement` decides a requirement whose conditions stand on their own, or one
+carried by a part that `-instantiate` created.
 
-A verdict is written to stdout and an undecided check to stderr, as is every
-other finding — diagnostics and warnings included — so
-`sysml -satisfy checks.sysml > verdicts.txt` keeps the results and leaves what
-went wrong on the terminal.
+Verdicts are written to standard output, while undecided checks and all other findings,
+including diagnostics and warnings, are written to standard error. Consequently,
+`sysml -satisfy checks.sysml > verdicts.txt` records the results and leaves any problems
+visible on the terminal.
 
 ## Checking as a gate
 
-`-validate` asks nothing of the model's conditions: it loads it and reports what
-analysis found, which is the lint step to run before any verdict is trusted.
+`-validate` evaluates none of the model's conditions. It loads the model and reports the
+findings of analysis, and should be run as a lint step before any verdict is relied upon.
 
 ```bash
 $ sysml -validate checks.sysml; echo "exit=$?"
@@ -151,10 +151,10 @@ sysml: bad.sysml did not analyse cleanly; no check was made
 exit=2
 ```
 
-A lone `-` names standard input wherever a file is taken, so a model can be
-piped in; its diagnostics are counted from `<stdin>`. A file really called `-` is
-read by naming it `./-`, and `-convert` needs `-from` for piped input because the
-stream carries no extension to take the format from.
+A single `-` denotes standard input wherever a file name is accepted, so a model can be piped
+in; its diagnostics are reported against `<stdin>`. To read a file that is actually named `-`,
+specify `./-`. `-convert` requires `-from` for piped input, because the stream carries no file
+extension from which to infer the format.
 
 ```bash
 $ cat checks.sysml | sysml -validate -
@@ -164,22 +164,20 @@ $ cat checks.sysml | sysml -validate -
 $ cat checks.sysml | sysml - -convert ttl -from sysml > model.ttl
 ```
 
-Every check mode is gated the same way, so a model with an error never reports a
-verdict about itself — a condition read out of a model the tool could not fully
-read would be an answer about a different model than the one you wrote. Name as
-many files as the model spans, in any order: the gate is about the model as a
-whole, so a reference from one file to a declaration in another resolves.
+Every check mode is gated in the same way, so a model containing an error never reports a
+verdict about itself: a condition read from a model that the tool could not fully parse would
+describe a different model than the one that was written. Name as many files as the model
+spans, in any order. The gate applies to the model as a whole, so a reference from one file to
+a declaration in another resolves correctly.
 
 ## Strict conformance
 
-OpenSysML accepts a few notations of its own that no SysML v2 production admits —
-`defer`, and the `choice`, `junction`, `history` and
-`entry`/`exit point` pseudostates. They are reported as
-warnings, so a model using them still analyses cleanly. `-strict` asks the other
-question — *is this file conforming SysML v2?* — by making those warnings errors:
+OpenSysML accepts several notations of its own that no SysML v2 production admits: `defer`, and
+the `choice`, `junction`, `history` and `entry`/`exit point` pseudostates. These are reported as
+warnings, so a model that uses them still analyses cleanly. `-strict` instead determines whether
+a file is conforming SysML v2, by promoting those warnings to errors.
 
-The monitor below deliberately uses the `defer` extension so the difference is
-visible:
+The state machine below uses the `defer` extension so that the difference is visible:
 
 ```sysml
 package M {
@@ -214,24 +212,23 @@ sysml: monitor.sysml did not analyse cleanly; no check was made
 exit=2
 ```
 
-There is no standard spelling for a deferred event, so a portable model states
-the machine's completion with `then done;` — as `warming` above does — and drops
-the `defer`. `-strict` changes nothing about what parses:
-the same file, the same tree, the same findings in the same places — only their
-severity, and with it the exit status and the tier gate. It is a portability check,
-so run it when a model has to be read by another SysML v2 tool; leave it off
-otherwise. Each finding names the standard notation to write instead, and
-[the conformance audit](../reference/grammar/conformance-audit.md) cites the
-production each extension is measured against. The same switch is `%strict` at
-the prompt ([4. The REPL](04-repl.md)), the `sysml.strictConformance` setting in
-an editor ([8. Editors](08-editors.md)) and `strict_conformance=True` from Python
+There is no standard notation for a deferred event, so a portable model states the machine's
+completion with `then done;`, as `warming` does above, and omits the `defer`. `-strict` does not
+change what parses: the same file produces the same tree and the same findings in the same
+places. Only their severity changes, and with it the exit status and the tier gate. Because it
+is a portability check, enable it when a model must be read by another SysML v2 tool and leave
+it disabled otherwise. Each finding names the standard notation to use instead, and
+[the conformance audit](../reference/grammar/conformance-audit.md) cites the production against
+which each extension is measured. The same setting is available as `%strict` at the prompt
+([4. The REPL](04-repl.md)), as the `sysml.strictConformance` editor setting
+([8. Editors](08-editors.md)) and as `strict_conformance=True` from Python
 ([9. Python](09-python.md)).
 
 ## Running behavior
 
-The debuggers have non-interactive forms that run to completion and report the
-values they produced. `-calc` takes the invocation, and `-action` and `-state`
-take the behavior's name optionally followed by the object performing it:
+The debuggers have non-interactive forms that run to completion and report the values they
+produce. `-calc` takes the invocation, while `-action` and `-state` take the name of the
+behavior, optionally followed by the object performing it:
 
 ```bash
 $ sysml -calc "MyModel::Margin(20.0, 100.0)" checks.sysml
@@ -261,18 +258,18 @@ $ sysml -state MyModel::Monitor -advance 15 checks.sysml
   Remaining events: 0
 ```
 
-A state machine only takes its initial transition unless `-advance` says how much
-simulated time to run it for; `-advance 0` runs it to the present, dispatching what
-is already due, and `-advance` with no `-state` to run is reported as a misuse
-rather than silently dropped. An action that stopped short of completing
-— a deadlock, or the step budget reached — is reported as a check that was never
-decided, i.e. status 2, since it produced no outputs to judge.
+A state machine takes only its initial transition unless `-advance` specifies how much simulated
+time to run for. `-advance 0` runs the machine to the present, dispatching whatever is already
+due, and `-advance` without a corresponding `-state` is reported as a misuse rather than
+silently ignored. An action that stops short of completing, whether through deadlock or by
+reaching the step budget, is reported as an undecided check (status 2), because it produced no
+outputs to evaluate.
 
 ## Machine-readable results
 
-`-json` reports the same run as one document, so a build step reads structure
-rather than parsing `✓`/`✗`. It reports the checks, not the model: use `-convert`
-to serialize the model itself.
+`-json` reports the same run as a single document, allowing a build step to read structured
+data rather than parse `✓` and `✗` markers. It reports the checks rather than the model; use
+`-convert` to serialize the model itself.
 
 ```bash
 $ sysml -satisfy -json checks.sysml; echo "exit=$?"
@@ -307,17 +304,16 @@ $ sysml -satisfy -json checks.sysml; echo "exit=$?"
 exit=1
 ```
 
-`status` is the worst verdict reached and `exit` the status the process exits
-with. A calculation's or a machine's values are reported as `values` entries, the
-findings of analysis as `diagnostics` — the warnings of a model that analyses
-cleanly as well as the errors of one that does not, each with the `file` it is in
-and its `line` and `column` there — and whatever stopped a check from being made as
-`errors`, so the whole document goes to stdout and nothing needs to be read off
-stderr.
+`status` is the worst verdict reached, and `exit` is the status with which the process exits.
+The values produced by a calculation or a state machine appear as `values` entries. The findings
+of analysis appear as `diagnostics`, covering both the warnings of a model that analyses cleanly
+and the errors of one that does not, each with the `file` in which it occurs and its `line` and
+`column`. Anything that prevented a check from being made appears as `errors`. The entire
+document is written to standard output, so nothing needs to be read from standard error.
 
 ## Running from a script
 
-`-e` evaluates without entering the prompt, so a model can be queried from a
+`-e` evaluates an expression without entering the prompt, so a model can be queried from a
 shell:
 
 ```bash
@@ -327,18 +323,17 @@ $ sysml -e "RdfInteropDemo::Rover::mass" examples/rdf-interop-demo.sysml
   = 899.0
 ```
 
-Two things matter before a pipeline depends on it:
+Two properties are important before a pipeline depends on this behavior:
 
-- **What was asked for is on stdout and what went wrong on stderr.** Evaluated
-  values, conversion output and verdict lines are results; a model's diagnostics
-  and warnings, a failed evaluation, a file that could not be read and the
-  `wrote <file> …` note of a successful `-convert -o` are not, so that stdout
-  carries the conversion alone.
-- **The exit status says whether the model answered what was asked**: `0` it did,
-  `1` it answered false, `2` it answered nothing. A warning leaves the status `0`.
-  The status codes are documented once, in
-  [reference/cli.md § Exit status](../reference/cli.md#exit-status),
-  with a CI recipe that gates on them.
+- **Requested output is written to standard output and problems to standard error.** Evaluated
+  values, conversion output and verdict lines are results. A model's diagnostics and warnings,
+  a failed evaluation, a file that could not be read, and the `wrote <file> …` note of a
+  successful `-convert -o` are not, so that standard output carries the conversion alone.
+- **The exit status reports whether the model answered the question asked**: `0` if it did, `1`
+  if it answered false, and `2` if it answered nothing. A warning leaves the status at `0`. The
+  status codes are documented in
+  [reference/cli.md § Exit status](../reference/cli.md#exit-status), together with a continuous
+  integration recipe that gates on them.
 
 ---
 

--- a/docs/guide/04-repl.md
+++ b/docs/guide/04-repl.md
@@ -1,8 +1,8 @@
 # 4. The REPL
 
-`sysml` with no model starts a prompt. What you type is a declaration, an expression, or a
-meta-command beginning with `%`; the declarations accumulate into a session model that every
-command answers about.
+Running `sysml` without a model starts an interactive prompt. Each entry is a declaration, an
+expression or a meta-command beginning with `%`. Declarations accumulate into a session model,
+which is the model every command reports on.
 
 ```
 $ sysml
@@ -16,33 +16,33 @@ sysml> %eval Demo::Wheel::diameter
   = 16.0
 ```
 
-The import is what makes `Real` resolvable, as in [chapter 2](02-first-model.md); a session that
-uses a library type without it is rejected with `unresolved reference: Real`.
+The import makes `Real` resolvable, as described in [chapter 2](02-first-model.md). A session
+that uses a library type without importing it is rejected with `unresolved reference: Real`.
 
 ## What a submission does
 
-A declaration is parsed and validated on submission, and the result is reported immediately —
-`✓` with the declared name, or the diagnostics. An unterminated declaration continues on the
-next line (`  ...>`) until its braces close.
+A declaration is parsed and validated on submission, and the result is reported immediately as
+either `✓` with the declared name or a set of diagnostics. An unterminated declaration continues
+on the next line (`  ...>`) until its braces close.
 
-Two properties of the session model are worth knowing before a long session:
+Two properties of the session model are important to understand before beginning a long session:
 
-- **A submission adds to the namespace already in the session.** Re-typing `package Demo { … }`
-  with one more member folds into the declaration already there — `note: added to the existing
-  package Demo (its other members are kept)` — rather than replacing its body. Re-typing a
-  member *does* replace that member, and says so; an empty body (`package Demo { }`) is how a
-  namespace is emptied.
-- **A submission only invalidates what it changed.** Objects created with `%instantiate` are
-  carried over while the declarations they were built from are untouched, and an
-  `%action`/`%state` debugging session over a declaration the submission left alone keeps
-  running. What a carried object keeps is its identity, not its execution: the behaviors its
-  type exhibits or performs are restarted from their initial states in the rebuilt analysis.
-  Everything dropped or restarted is reported as a `note:` line saying what happened.
+- **A submission adds to the namespace already present in the session.** Re-entering
+  `package Demo { … }` with an additional member merges into the existing declaration —
+  `note: added to the existing package Demo (its other members are kept)` — rather than
+  replacing its body. Re-entering a member does replace that member, and the replacement is
+  reported. An empty body (`package Demo { }`) empties the namespace.
+- **A submission invalidates only what it changed.** Objects created with `%instantiate` are
+  retained while the declarations they were built from remain untouched, and an `%action` or
+  `%state` debugging session over an unaffected declaration continues to run. A retained object
+  keeps its identity but not its execution state: the behaviors its type exhibits or performs
+  restart from their initial states in the rebuilt analysis. Everything dropped or restarted is
+  reported on a `note:` line describing what occurred.
 
-`%list` shows the session's declarations, `%clear` resets it, and `%save` writes it out
-([chapter 7](07-saving-and-rdf.md)). `%clear` replaces every declaration, so nothing it held can be
-proved to still exist: it reports what it took, and the next command that would have used it says why
-it is gone.
+`%list` shows the session's declarations, `%clear` resets the session, and `%save` writes it out
+([chapter 7](07-saving-and-rdf.md)). Because `%clear` discards every declaration, nothing it held
+remains available: it reports what was discarded, and the next command that would have used it
+explains why it is no longer present.
 
 ```
 sysml> %clear
@@ -54,8 +54,8 @@ sysml> %instances
 
 ## Seeing the model
 
-`%print` writes the session back as notation, at the prompt — the whole model, or one element and
-its body when a name is given:
+`%print` writes the session back to the prompt as notation, either the whole model or, when a
+name is given, a single element and its body:
 
 ```
 sysml> package Demo {
@@ -72,20 +72,20 @@ part def Vehicle {
 }
 ```
 
-It is the writer `%save` writes a `.sysml` file with, so a print keeps comments and the text as it
-was written, re-indented the way a save would be, and what it prints can be typed or loaded back to
-rebuild the same model.
-Names are spelled as every other command spells them (`%print 'My Pkg'::Car`). Printing reads the
-session and nothing more: no object is created, and an `%action`/`%state` session keeps running
-across it. An empty session, a name nothing declares, and a name whose element this session holds
-no source of each say so in one line. RDF is `%save`'s `.ttl` path ([chapter 7](07-saving-and-rdf.md));
-a print is notation only.
+`%print` uses the same writer that `%save` uses for a `.sysml` file, so it preserves comments and
+the original text, re-indented as a save would indent it, and its output can be typed or loaded
+back to rebuild the same model. Names are written as in every other command
+(`%print 'My Pkg'::Car`). Printing only reads the session: it creates no objects, and an
+`%action` or `%state` session continues across it. An empty session, a name that nothing
+declares, and a name whose element the session holds no source for are each reported on a single
+line. RDF output is available through `%save` with a `.ttl` path
+([chapter 7](07-saving-and-rdf.md)); `%print` emits notation only.
 
 ## A name that needs quotes
 
-A name the notation has to quote — one containing a space, a keyword used as a name, punctuation —
-is written to a command exactly as it is written in a model, quotes included, and a quoted segment
-can sit anywhere in the chain:
+A name that the notation requires to be quoted — one containing a space or punctuation, or a
+keyword used as a name — is supplied to a command exactly as it is written in a model, including
+the quotes. A quoted segment may appear anywhere in the qualified name:
 
 ```
 sysml> package 'My Pkg' { part def Car { attribute m = 5.0; } }
@@ -94,8 +94,9 @@ sysml> %features 'My Pkg'::Car
 sysml> %eval 'My Pkg'::Car::m
 ```
 
-The unquoted spelling of a name that does not need quoting is unchanged. Commands report a name back
-quoted the same way, so a name from `%search` can be typed into the next command as it appears.
+Names that do not require quoting are written unquoted, as before. Commands report names back
+with the same quoting, so a name returned by `%search` can be entered into the next command
+exactly as it appears.
 
 ## Loading files
 
@@ -105,20 +106,20 @@ sysml> %load examples/*.sysml
 sysml> %load examples/
 ```
 
-`%load` takes files, globs and directories, and submits their contents as if typed — with one
-difference: a loaded namespace keeps the file's identity, so re-typing it at the prompt *replaces*
-it (`note: replaced package …`) rather than adding to it. Edit the file and load it again. Tab
-completes paths after `%load` and `%save`, and completes meta-commands and symbol names
-everywhere else.
+`%load` accepts files, globs and directories, and submits their contents as though they had been
+typed, with one difference: a loaded namespace retains the identity of its file, so re-entering
+it at the prompt *replaces* it (`note: replaced package …`) rather than adding to it. To change a
+loaded file, edit it and load it again. Tab completion completes paths after `%load` and `%save`,
+and completes meta-commands and symbol names elsewhere.
 
-A file whose text the parser cannot read is reported the way a typed declaration is — the same
-diagnostic, pointing into the file at its own line — and nothing of it enters the session, so the
-next submission is parsed against what was there before the load. In the non-interactive path the
-diagnostics of a load are errors, so a script loading a broken file fails rather than continuing
-against an empty session.
+A file the parser cannot read is reported in the same way as a typed declaration, with the same
+diagnostic pointing at the corresponding line of the file. None of its contents enter the
+session, so the next submission is parsed against the model as it stood before the load. In the
+non-interactive path, the diagnostics of a load are errors, so a script that loads a malformed
+file fails rather than continuing against an empty session.
 
-Two loaded files that both open `package P` declare two packages of that name, and the load says
-so:
+Two loaded files that both open `package P` declare two packages of that name, and the load
+reports this:
 
 ```
 sysml> %load a.sysml b.sysml
@@ -126,17 +127,18 @@ note: P is opened by more than one loaded file; each opening stays a declaration
 member of one is not visible unqualified in the other — qualify it (P::member)
 ```
 
-Each file keeps its own identity — that is what makes re-loading one of them replace only its own
-contribution — so the two openings cannot be one namespace without a file's edit silently deleting
-the other file's members. Both openings' members are declared and reachable qualified
-(`P::Wheel`, `P::Axle`); an unqualified reference across the two does not resolve. Re-typing a
-package at the prompt is unaffected: it still folds into the package already in the session.
+Each file retains its own identity, which is what allows re-loading one of them to replace only
+its own contribution. Merging the two openings into a single namespace would therefore allow an
+edit to one file to silently delete the other file's members. The members of both openings are
+declared and reachable when qualified (`P::Wheel`, `P::Axle`), but an unqualified reference
+across the two does not resolve. Re-entering a package at the prompt is unaffected: it still
+merges into the package already present in the session.
 
 ## Finding what a build offers
 
-`%search` looks a substring up across the declared and library symbols with the kind of each,
-and `%builtins` lists the library functions this build evaluates directly — which is how to tell
-whether an expression will evaluate before writing a model around it.
+`%search` looks up a substring across the declared and library symbols and reports the kind of
+each. `%builtins` lists the library functions that the current build evaluates directly, which
+determines whether an expression can be evaluated before a model is written around it.
 
 ```
 sysml> %search Vehicle
@@ -144,15 +146,16 @@ sysml> %builtins
 sysml> %view Demo::summary
 ```
 
-`%view <name>` reports what a view exposes, the views nested in it, and whether it conforms to the
-viewpoints it satisfies. Conformance is read-only and reported in declaration order: each `satisfy`
-carries a verdict — `conforms`, `violated` or `unevaluable` — then each concern the viewpoint frames
-carries its own, and a concern whose condition fails names the exposed element it failed for with
-the reason. A `satisfy` inherited from a specialized view is marked `(from <view>)`, a concern the
-viewpoint frames but the view does not is `violated`, and a concern stating no condition, or naming
-one that does not resolve, is `unevaluable` with the reason rather than a pass.
-The verdicts and the treatment of a nested view's framing are this tool's choice: SysML v2 leaves
-verification verdict semantics non-normative.
+`%view <name>` reports the elements a view exposes, the views nested within it, and whether it
+conforms to the viewpoints it satisfies. Conformance checking is read-only and reported in
+declaration order. Each `satisfy` carries a verdict of `conforms`, `violated` or `unevaluable`,
+followed by a verdict for each concern the viewpoint frames; a concern whose condition fails
+names the exposed element it failed for, together with the reason. A `satisfy` inherited from a
+specialized view is marked `(from <view>)`. A concern that the viewpoint frames but the view does
+not is reported as `violated`, and a concern that states no condition, or names one that does not
+resolve, is reported as `unevaluable` with the reason rather than as a pass. These verdicts, and
+the treatment of a nested view's framing, are decisions made by this implementation, because
+SysML v2 leaves verification verdict semantics non-normative.
 
 ```
 sysml> package Demo {
@@ -223,16 +226,17 @@ view Demo::report
       concern modularity: conforms
 ```
 
-A name the session cannot find is offered the qualified names it is known under, nearest scope
-first — what the session itself declares before the library, and a package's member before a name
-nested inside another element — and at most three of them.
+When a name cannot be found, the session suggests the qualified names under which it is known,
+nearest scope first — declarations in the session before library symbols, and a package's member
+before a name nested inside another element — up to a maximum of three suggestions.
 
 ## Rendering a view
 
-`%render <name>` turns the exposed set into the rendering the view's `render` member states —
-a containment tree with nested views as subtrees, an interconnection diagram of the exposed parts and
-the connections between them, a state machine's states and transitions, an action's nodes and
-successions, or a table of the exposed elements — and a tree where the view states none:
+`%render <name>` renders the exposed set in the form the view's `render` member specifies: a
+containment tree with nested views as subtrees, an interconnection diagram of the exposed parts
+and the connections between them, a state machine's states and transitions, an action's nodes and
+successions, or a table of the exposed elements. A view that specifies no rendering is rendered
+as a tree:
 
 ```
 sysml> %render Demo::summary
@@ -246,27 +250,29 @@ view Demo::summary::detail
     attribute diameter (Real)
 ```
 
-A view stating `render asElementTable;` renders as rows instead — the exposed elements, what they
-declare, and the views nested in the rendered one — as aligned columns.
+A view that states `render asElementTable;` is rendered as aligned columns instead, listing the
+exposed elements, what they declare, and the views nested within the rendered view.
 
 `%render <name> mermaid` writes a graph-shaped rendering as a Mermaid diagram, and
-`%render <name> markdown` writes a table as a Markdown table; either pastes into Markdown or an
-editor as-is, and asking for a form the kind is not written in names the one it is. State and action
-renderings read the lowered graphs the runtime executes, so what is drawn is what runs; the
-rendering itself is this tool's output, since SysML v2 §10.2 specifies the notation, not how a tool
-draws it.
+`%render <name> markdown` writes a table as a Markdown table. Either form can be pasted directly
+into a Markdown document or an editor, and requesting a form that the rendering kind does not
+support reports the form it does support. State and action renderings read the lowered graphs
+that the runtime executes, so the rendering reflects what actually runs. The rendering itself is
+specific to this implementation, because SysML v2 §10.2 specifies the notation rather than how a
+tool draws it.
 
-Rendering reads the model and nothing else: it creates no object, and a `%render` between two
-`%step`s leaves an action or state debugging session exactly where it was. A view exposing nothing
-renders empty and says so, a rendering kind this build does not produce names the kind and the view
-rather than drawing something else, and an element the rendering cannot represent is reported
-rather than dropped. Outside the prompt the same rendering is
+Rendering only reads the model: it creates no objects, and a `%render` issued between two `%step`
+commands leaves an action or state debugging session unchanged. A view that exposes nothing
+renders as empty and reports this, a rendering kind the build does not produce is reported by
+name together with the view rather than substituted, and an element the rendering cannot
+represent is reported rather than omitted. The equivalent operation outside the prompt is
 [`sysml -render`](../reference/cli.md#rendering-a-view).
 
 ## Where an expression is evaluated
 
-`%eval <expression>` evaluates in the namespace the session is working in — the last one it declared
-— so a scratch package typed later moves it. Name a context to pin it instead:
+`%eval <expression>` evaluates in the namespace the session is currently working in, which is the
+most recently declared one, so declaring a scratch package later changes that context. To pin the
+context, name it explicitly:
 
 ```
 sysml> %eval in Demo::Vehicle : mass * 2
@@ -281,14 +287,15 @@ sysml> %eval in Demo::Vehicle : mass * 2
   = 3000.0
 ```
 
-The pinned name may be an element, whose namespace the expression then reads, or a name an object
-was materialized under, whose feature values it reads — the same values an unpinned `%eval` reads after
-`%instantiate`. The `:` separates the context from the expression; `::` inside the name is not a
+The pinned name may be an element, in which case the expression reads that element's namespace,
+or a name under which an object was materialized, in which case the expression reads that
+object's feature values — the same values an unpinned `%eval` reads after `%instantiate`. The `:`
+character separates the context from the expression; the `::` within a qualified name is not a
 separator.
 
-## Asking questions
+## Command summary
 
-| To ask | Use | Chapter |
+| To determine | Use | Chapter |
 |--------|-----|---------|
 | what a view shows | `%view`, `%render` | this chapter |
 | what an expression is worth | `%eval`, `%eval in … : …` | [5](05-checking.md) |
@@ -305,10 +312,10 @@ separator.
 
 Every command, with its arguments, is [reference/repl-commands.md](../reference/repl-commands.md).
 
-## Without the prompt
+## Non-interactive use
 
-`-e` evaluates one expression against a model and exits, which is the same session machinery
-without a terminal — see [chapter 3](03-command-line.md#running-from-a-script).
+`-e` evaluates a single expression against a model and exits, using the same session machinery
+without a terminal. See [chapter 3](03-command-line.md#running-from-a-script).
 
 ---
 

--- a/docs/guide/05-checking.md
+++ b/docs/guide/05-checking.md
@@ -1,8 +1,9 @@
 # 5. Expressions, calculations, constraints and requirements
 
-What the runtime evaluates, and how each kind of check reports. A constraint declared on a
-definition is checked against the object carrying it, so instantiate first when you want a
-verdict about a value rather than about a default.
+This chapter describes what the runtime evaluates and how each kind of check reports its result.
+A constraint declared on a definition is checked against the object that carries it, so
+instantiate the definition first to obtain a verdict about a concrete value rather than about a
+default.
 
 ## Expressions
 
@@ -112,7 +113,8 @@ sysml> %requirement SafetyReq
 ✓ Requirement SafetyReq satisfied
 ```
 
-**See [examples/repl-behavioral-demo.sysml](../../examples/repl-behavioral-demo.sysml) for comprehensive examples.**
+For further examples, see
+[examples/repl-behavioral-demo.sysml](../../examples/repl-behavioral-demo.sysml).
 
 ---
 

--- a/docs/guide/06-behavior.md
+++ b/docs/guide/06-behavior.md
@@ -1,9 +1,9 @@
 # 6. Behavior: actions and state machines
 
-An action or a state machine is executed, not just parsed: a debugger steps it, and the
-non-interactive `-action`/`-state` flags run it to completion and report what it produced.
-An object may perform the behavior, in which case what it sends routes over that object's
-connections.
+Actions and state machines are executed rather than merely parsed. A debugger steps through
+them, and the non-interactive `-action` and `-state` flags run them to completion and report the
+values produced. An object may perform the behavior, in which case the messages it sends are
+routed over that object's connections.
 
 **Action execution (step-by-step):**
 ```sysml
@@ -42,11 +42,10 @@ sysml> %continue
 
 **State machine execution:**
 
-A machine completes when a transition reaches `done`, the end shot the standard
-library gives every state: entering it runs the exit actions and the machine
-reports itself completed. Inside orthogonal regions each region has its own
-`done`, and the machine completes only once every concurrent region has reached
-it.
+A machine completes when a transition reaches `done`, the terminal state that the standard
+library provides for every state machine. Entering it runs the exit actions, after which the
+machine reports itself as completed. Within orthogonal regions, each region has its own `done`,
+and the machine completes only once every concurrent region has reached it.
 
 ```sysml
 sysml> state TrafficLight {
@@ -109,16 +108,18 @@ sysml> %advance 30
 - `%advance <time>` — Advance simulation time by `<time>` units, processing every event due
 - `%stop` — Stop debugging
 
-**See [examples/action-executor-demo.sysml](../../examples/action-executor-demo.sysml),
-[examples/orthogonal-regions-demo.sysml](../../examples/orthogonal-regions-demo.sysml), and
-[examples/pseudostates-demo.sysml](../../examples/pseudostates-demo.sysml) for complete workflows.**
+For complete workflows, see
+[examples/action-executor-demo.sysml](../../examples/action-executor-demo.sysml),
+[examples/orthogonal-regions-demo.sysml](../../examples/orthogonal-regions-demo.sysml) and
+[examples/pseudostates-demo.sysml](../../examples/pseudostates-demo.sysml).
 
 ## An object runs the behaviors its type exhibits
 
 A type that exhibits a state machine or performs an action binds that behavior to every object of
-the type: materializing the object gives it an execution of its own, bound to its identity. Two
-objects of one type run two machines, with their own current state, event queue and feature values,
-and what a body assigns is the feature value of the object performing it.
+the type: materializing an object gives it an execution of its own, bound to its identity. Two
+objects of the same type run two independent machines, each with its own current state, event
+queue and feature values, and an assignment in a behavior body writes the feature value of the
+object performing it.
 
 ```sysml
 sysml> part def Monitor {
@@ -164,36 +165,38 @@ Features:
     apply = <unknown>
 ```
 
-`%instantiate` started the machine and `%state Monitor` bound the debugger to *that object's*
-machine rather than to a detached run of the usage, so `%step`, `%advance`, `%current` and
-`%events` drive it and `%features` shows what its entry actions wrote — `1` from `idle`, then
-`10` more from `awake` once the timer was dispatched.
+`%instantiate` started the machine, and `%state Monitor` bound the debugger to *that object's*
+machine rather than to a detached run of the usage. `%step`, `%advance`, `%current` and `%events`
+therefore drive that machine, and `%features` shows the values its entry actions wrote: `1` from
+`idle`, followed by `10` more from `awake` once the timer was dispatched.
 
 **When a machine starts, and how far it runs.** The object's feature values are built and its
-constant defaults evaluated first, so an entry action sees declared initial values; the machine is
-then initialized and run to *quiescence* — no event due at the current time, no runnable do action,
-no message in flight. A machine waiting on a timer or an `accept` is quiescent, and advancing time
-is what moves it on. Objects that signal each other are drained together, bounded by the event and
-do-step budgets in [reference/environment.md](../reference/environment.md): an exchange that never
-settles reports a budget error rather than hanging. Materializing the same name twice makes a second
-object with its own identity and its own machines; `%instantiate` reports the new object, and the
-name then denotes it. An exhibited machine with no initial state is reported; a performed action that
-states no flow simply has no step to perform, so the object is still created. A performed action
-parked at an `accept` is quiescent too, and a message a sibling object sends later wakes it.
+constant defaults evaluated first, so an entry action observes the declared initial values. The
+machine is then initialized and run to *quiescence*, meaning that no event is due at the current
+time, no do action is runnable, and no message is in flight. A machine waiting on a timer or an
+`accept` is quiescent, and advancing time is what allows it to proceed. Objects that signal one
+another are drained together, bounded by the event and do-step budgets documented in
+[reference/environment.md](../reference/environment.md); an exchange that never settles reports a
+budget error rather than hanging. Materializing the same name twice creates a second object with
+its own identity and its own machines: `%instantiate` reports the new object, and the name then
+refers to it. An exhibited machine with no initial state is reported as such. A performed action
+that states no flow has no step to perform, so the object is still created. A performed action
+waiting at an `accept` is likewise quiescent, and a message sent later by a sibling object
+resumes it.
 
-**Editing the model while an object runs.** An unrelated declaration keeps the object — its identity
-survives the rebuilt analysis — but not the execution it was running: an execution belongs to the
-graph, names and message bus of the analysis it started in, so the object's behaviors are **started
-again from their initial states** in the rebuilt analysis and what the discarded run wrote is
-dropped with them. The restart is reported (`note: the exhibited state machine modes of object #1 was
-restarted from its initial state because the model was rebuilt`), and a `%state` session follows the
-object onto its restarted machine, so a restarted behavior exchanges messages with objects
-materialized after the edit like any other. Re-declaring what the object runs — its type's features
-or the body of a machine or action it runs — makes it a different object, so it is dropped with a
-reported reason and `%instantiate` starts a fresh one.
+**Editing the model while an object runs.** An unrelated declaration preserves the object, whose
+identity survives the rebuilt analysis, but not the execution it was running. An execution belongs
+to the graph, names and message bus of the analysis in which it started, so the object's behaviors
+are **restarted from their initial states** in the rebuilt analysis, and any values written by the
+discarded run are dropped with it. The restart is reported (`note: the exhibited state machine
+modes of object #1 was restarted from its initial state because the model was rebuilt`), and a
+`%state` session follows the object onto its restarted machine, so a restarted behavior exchanges
+messages with objects materialized after the edit in the usual way. Re-declaring what the object
+runs — its type's features, or the body of a machine or action it runs — produces a different
+object, so the original is dropped with a reported reason and `%instantiate` creates a new one.
 
-**Invoking an operation.** `%invoke <object> <op> [<p>=<expr>]` runs an action the object's type
-owns, performed by that object:
+**Invoking an operation.** `%invoke <object> <op> [<p>=<expr>]` runs an action owned by the
+object's type, performed by that object:
 
 ```sysml
 sysml> %invoke Monitor bumpBy n=4
@@ -211,16 +214,16 @@ Features:
     apply = <unknown>
 ```
 
-Each argument is written `<parameter>=<expression>`; an unbound parameter, an argument naming no
-parameter, and an operation the type does not own are each reported as errors. A `calc` or
-`constraint` named as an operation is not invocable this way yet.
+Each argument is written as `<parameter>=<expression>`. An unbound parameter, an argument that
+names no parameter, and an operation the type does not own are each reported as errors. A `calc`
+or `constraint` named as an operation cannot yet be invoked in this way.
 
 ## Token-flow patterns
 
-Every model below is in
-[examples/action-executor-demo.sysml](../../examples/action-executor-demo.sysml), and the
-output shown is what `sysml -action ActionExecutorDemo::<name> examples/action-executor-demo.sysml`
-prints.
+Each model below is contained in
+[examples/action-executor-demo.sysml](../../examples/action-executor-demo.sysml), and the output
+shown is that of
+`sysml -action ActionExecutorDemo::<name> examples/action-executor-demo.sysml`.
 
 ### Sequential: start → action → done
 
@@ -236,7 +239,7 @@ action sequential {
 }
 ```
 
-One token spawns at `start`, moves to `compute`, which runs its body, and is consumed at
+A single token is created at `start`, moves to `compute`, which runs its body, and is consumed at
 `done`:
 
 ```
@@ -277,9 +280,9 @@ action forkJoin {
 }
 ```
 
-`fork` puts a token on each outgoing succession; `join` is an AND-join, so it waits for a
-token on *every* incoming succession before one continues. A fork duplicates control, not
-values: all three branches are steps of the one performance, so every assignment is visible
+`fork` places a token on each outgoing succession. `join` is an AND-join, so it waits for a token
+on *every* incoming succession before a single token continues. A fork duplicates control rather
+than values: all three branches are steps of the same performance, so every assignment is visible
 when it completes.
 
 ```bash
@@ -292,7 +295,8 @@ $ sysml -action ActionExecutorDemo::forkJoin examples/action-executor-demo.sysml
     task3 = 30
 ```
 
-A branch that never arrives is a deadlock, not a failure: the run is reported as undecided.
+A branch that never arrives constitutes a deadlock rather than a failure, and the run is reported
+as undecided.
 
 ---
 
@@ -320,8 +324,8 @@ action conditional {
 }
 ```
 
-`decide` evaluates its guards in the order written, with the action's features in scope, and
-takes the first that holds; `else` is taken when none does. With `x = 15`:
+`decide` evaluates its guards in the order written, with the action's features in scope, and takes
+the first guard that holds. The `else` branch is taken when no guard holds. With `x = 15`:
 
 ```bash
 $ sysml -action ActionExecutorDemo::conditional examples/action-executor-demo.sysml
@@ -332,14 +336,14 @@ $ sysml -action ActionExecutorDemo::conditional examples/action-executor-demo.sy
     x = 15
 ```
 
-Set `x` to `5` and `taken` is `2`. The state-machine counterparts — orthogonal regions,
-choice and junction — are in
+Setting `x` to `5` yields a `taken` value of `2`. The state-machine counterparts — orthogonal
+regions, choice and junction — appear in
 [examples/orthogonal-regions-demo.sysml](../../examples/orthogonal-regions-demo.sysml) and
-[examples/pseudostates-demo.sysml](../../examples/pseudostates-demo.sysml), and every case the executors are held to is under
-`internal/core/runtime/testdata/conformance/`.
+[examples/pseudostates-demo.sysml](../../examples/pseudostates-demo.sysml), and every case the
+executors are held to is located under `internal/core/runtime/testdata/conformance/`.
 
-A run that stops short — a deadlock, or a budget reached — is reported as a check that was never
-decided rather than as a failure; the bounds are in
+A run that stops short, whether through deadlock or by reaching a budget, is reported as an
+undecided check rather than as a failure. The applicable bounds are documented in
 [reference/environment.md](../reference/environment.md).
 
 ---

--- a/docs/guide/07-saving-and-rdf.md
+++ b/docs/guide/07-saving-and-rdf.md
@@ -1,22 +1,22 @@
 # 7. Saving, and converting to RDF
 
-A model is written in two representations — SysML v2 notation (`.sysml`, `.kerml`) and RDF in
-Turtle (`.ttl`) — and converted between them, from the prompt, the command line, or over gRPC.
-No JSON is involved anywhere in this path, not even as an intermediate form.
+A model can be written in two representations, SysML v2 notation (`.sysml`, `.kerml`) and RDF in
+Turtle (`.ttl`), and converted between them from the prompt, the command line or over gRPC. JSON
+is not used anywhere in this path, including as an intermediate form.
 
-The vocabulary each triple uses, and what the mapping does not cover, is
-[reference/rdf-mapping.md](../reference/rdf-mapping.md).
+The vocabulary used by each triple, and the constructs the mapping does not cover, are documented
+in [reference/rdf-mapping.md](../reference/rdf-mapping.md).
 
-> **RDF conversion is experimental.** It covers model structure and the behavior
-> its bodies state, refuses what it cannot write back, and its vocabulary may
-> change without a compatibility path, so every run that converts RDF says so.
-> Saving to `.sysml` or `.kerml` is stable and exact. See
+> **RDF conversion is experimental.** It covers model structure and the behavior stated by model
+> bodies, refuses any construct it cannot write back, and its vocabulary may change without a
+> compatibility path, which every run that converts RDF reports. Saving to `.sysml` or `.kerml`
+> is stable and exact. See
 > [reference/rdf-mapping.md § Status](../reference/rdf-mapping.md#status-experimental).
 
 ## Saving a session
 
-`%save` writes the session out. The format follows the extension — `.sysml` for
-notation, `.ttl` for RDF Turtle:
+`%save` writes the session out, selecting the format from the file extension: `.sysml` for
+notation and `.ttl` for RDF Turtle.
 
 ```bash
 sysml> package Demo { private import ScalarValues::*; part def Vehicle { attribute mass : Real = 1500.0; } }
@@ -30,14 +30,13 @@ note: RDF conversion is experimental: the mapping covers model structure and the
 saved 1487 bytes of ttl to my_model.ttl
 ```
 
-A leading `~` is expanded, an existing file is replaced and the replacement is
-stated, and the write is atomic — an interrupted save leaves the previous file
-intact. A file that already exists keeps its permissions, and a symlink is
-written through rather than replaced.
+A leading `~` is expanded, an existing file is replaced and the replacement is reported, and the
+write is atomic, so an interrupted save leaves the previous file intact. An existing file retains
+its permissions, and a symlink is written through rather than replaced.
 
-A session that does not fully parse is still saved as notation: that file is
-your own text re-indented, so the syntax errors are reported as warnings and the
-work is never trapped in the REPL.
+A session that does not fully parse is still saved as notation. The resulting file contains the
+authored text, re-indented, so the syntax errors are reported as warnings and no work is left
+inaccessible in the REPL.
 
 ```bash
 sysml> package Demo {
@@ -57,9 +56,9 @@ warning: the file is saved as typed; fix these and save again
 saved 47 bytes of sysml to my_model.sysml
 ```
 
-`.ttl` keeps the refusal, because a graph built from a tree the parser only
-partly recovered would be quietly missing declarations. So does
-`sysml -convert`, where the source already exists on disk.
+The `.ttl` direction still refuses such a session, because a graph built from a tree the parser
+only partly recovered would silently omit declarations. `sysml -convert` behaves the same way,
+since the source already exists on disk.
 
 The same conversion is available without starting the REPL:
 
@@ -69,8 +68,8 @@ $ sysml my_model.ttl -convert sysml -o back.sysml      # RDF to notation
 $ sysml my_model.sysml -convert ttl                    # to stdout
 ```
 
-The model is named the way it is everywhere else on this command line, and
-`-convert` names the format to convert it to.
+The model is named as it is in every other invocation of the command, and `-convert` names the
+target format.
 
 ## Converting from the command line
 
@@ -80,44 +79,42 @@ sysml model.ttl -convert sysml -o model.sysml   # RDF to notation
 sysml model.sysml -convert ttl                  # to stdout
 ```
 
-The model is a positional argument, as it is for every other mode of the
-command, and `-convert` names the format to convert it to. Flags may be written
-before or after the model.
+The model is a positional argument, as in every other mode of the command, and `-convert` names
+the target format. Flags may be written before or after the model.
 
-The input format is taken from the file extension. When that extension is
-missing or unrecognized, `-from` names it:
+The input format is inferred from the file extension. When the extension is missing or
+unrecognized, specify it with `-from`:
 
 ```bash
 sysml input.txt -convert ttl -from sysml
 ```
 
-`-convert`/`-from` accept `sysml`, `kerml`, `text`, `ttl`, `turtle` and `rdf`.
-The output path plays no part in choosing the format, so a destination with no
-extension — `-o /dev/null`, a FIFO — needs nothing extra.
+`-convert` and `-from` accept `sysml`, `kerml`, `text`, `ttl`, `turtle` and `rdf`. The output path
+plays no part in format selection, so a destination without an extension, such as `-o /dev/null`
+or a FIFO, requires no additional flags.
 
 Converting to the same format rewrites the input: notation is reformatted, and
 Turtle is normalized (prefixes sorted, predicates grouped by subject).
 
 ### Exit status
 
-The command exits non-zero and writes nothing on any input it cannot convert
-faithfully — a syntax error in the notation, malformed Turtle, or an RDF
-construct outside the mapping below. It never writes a partial model.
+The command exits with a non-zero status and writes nothing for any input it cannot convert
+faithfully, whether a syntax error in the notation, malformed Turtle, or an RDF construct outside
+the mapping. It never writes a partial model.
 
 ## Converting over gRPC and from Python
 
-The same conversion is a service method, `Convert`, reported as the `convert`
-capability by `GetServerInfo`. It reads a `file_path` the service opens or
-`content` carried inline, takes the format names `-from`/`-to` take, and returns
-the written text with its formats, or an `error` plus the diagnostics explaining
-it. `tolerate_syntax_errors` writes notation despite syntax errors, and is
-rejected for any direction that builds a graph, where an unparsed declaration
-would go missing without saying so.
+The same conversion is available as the service method `Convert`, reported as the `convert`
+capability by `GetServerInfo`. It accepts either a `file_path` that the service opens or `content`
+carried inline, takes the same format names as `-from` and `-to`, and returns the written text
+with its formats, or an `error` together with the diagnostics that explain it.
+`tolerate_syntax_errors` writes notation despite syntax errors and is rejected for any direction
+that builds a graph, where an unparsed declaration would be omitted without notice.
 
-A response whose conversion went through the RDF mapping sets `experimental` and
-`experimental_notice`, on a refusal as well as on a success, so a client learns
-the status from the response rather than from this page. opensysml raises it as an
-`ExperimentalFeatureWarning`, which `warnings.simplefilter` can silence:
+A response whose conversion used the RDF mapping sets `experimental` and `experimental_notice` on
+both refusals and successes, so a client obtains the status from the response rather than from
+this page. The `opensysml` client raises this as an `ExperimentalFeatureWarning`, which
+`warnings.simplefilter` can suppress:
 
 ```python
 import warnings
@@ -134,33 +131,31 @@ model.save("model.ttl")                          # SysML notation to RDF
 opensysml.convert("sysml", file_path="model.ttl")  # and back
 ```
 
-The client API is [reference/python-api.md](../reference/python-api.md), and using it as a task is
-[chapter 9](09-python.md).
+The client API is documented in [reference/python-api.md](../reference/python-api.md), and
+[chapter 9](09-python.md) describes its use.
 
 ## Round-tripping
 
 `notation → RDF → notation` returns an equivalent model, and
-`notation → RDF → notation → RDF` returns the *same graph* — which is the
-property the test suite asserts, over the fixtures in
-`internal/core/export/testdata/convert/`.
+`notation → RDF → notation → RDF` returns the *same graph*. This is the property asserted by the
+test suite over the fixtures in `internal/core/export/testdata/convert/`.
 
-The notation on the far side of a round trip is equivalent but not always
-character-identical: a reference may come back written relative to a different
-scope, and a clause written `:>` comes back as `specializes`. Both parse to the
-same model, and the second conversion to RDF proves it.
+The notation produced by a round trip is equivalent but not always character-identical: a
+reference may be written relative to a different scope, and a clause written `:>` is returned as
+`specializes`. Both forms parse to the same model, which the second conversion to RDF confirms.
 
-**A save to `.sysml` is different, and is exact.** It writes the session's own
-source through the formatter rather than re-printing the graph, so comments,
-notes and spacing survive. Only the `.ttl` direction goes through the mapping.
-The syntax is still checked: every direction rejects notation the parser cannot
-read, so a save never quietly reformats a model that will not parse.
+**A save to `.sysml` behaves differently and is exact.** It writes the session's own source
+through the formatter rather than re-printing the graph, so comments, notes and spacing are
+preserved. Only the `.ttl` direction uses the mapping. Syntax is checked in every direction, and
+notation the parser cannot read is rejected, so a save never silently reformats a model that does
+not parse.
 
 ## A worked example
 
-[`examples/rdf-interop-demo.sysml`](../../examples/rdf-interop-demo.sysml) is the
-reference model for this document: a rover and its ground link, declared with
-packages, definitions, usages, ports, a connection, multiplicity, values and
-documentation — all inside the mapping — so it converts and comes back:
+[`examples/rdf-interop-demo.sysml`](../../examples/rdf-interop-demo.sysml) is the reference model
+for this chapter: a rover and its ground link, declared with packages, definitions, usages, ports,
+a connection, multiplicity, values and documentation, all of which the mapping covers, so the
+model converts in both directions:
 
 ```bash
 $ sysml examples/rdf-interop-demo.sysml -convert ttl -o /tmp/rover.ttl
@@ -171,21 +166,20 @@ note: RDF conversion is experimental: the mapping covers model structure and the
 wrote /tmp/rover-back.sysml (sysml, 877 bytes)
 ```
 
-Converting the returned notation again yields a byte-identical graph — the
-round-trip property described above. The `//` header comment is the one thing
-lost, as [reference/rdf-mapping.md](../reference/rdf-mapping.md) describes; the package's `doc` and `comment` are
-declarations and survive.
+Converting the returned notation again yields a byte-identical graph, which is the round-trip
+property described above. The `//` header comment is the only content lost, as described in
+[reference/rdf-mapping.md](../reference/rdf-mapping.md); the package's `doc` and `comment` are
+declarations and are preserved.
 
 [`examples/semantic-layer/demo.sysml`](../../examples/semantic-layer/demo.sysml)
 and [`examples/repl-behavioral-demo.sysml`](../../examples/repl-behavioral-demo.sysml)
-convert too, as do most `parser_features_demo_*.kerml` files (except
-`..._advanced_bodies.kerml`, which computes a value, and two that each declare
-one name twice). The behavior a body states converts as well — states, regions,
-substates, action nodes, assignments and transitions all have a mapping. What is
-refused is what the notation could not be rebuilt from: an expression the graph
-would have to compute, a name two members of one body share, or a declaration
-with no name. A refusal names the construct it stopped at and points at saving
-the source instead:
+also convert, as do most `parser_features_demo_*.kerml` files, with the exception of
+`..._advanced_bodies.kerml`, which computes a value, and two files that each declare one name
+twice. The behavior stated by a body converts as well: states, regions, substates, action nodes,
+assignments and transitions all have a mapping. Refusals apply to constructs from which the
+notation could not be rebuilt, such as an expression the graph would have to compute, a name
+shared by two members of one body, or a declaration without a name. A refusal names the construct
+at which conversion stopped and recommends saving the source instead:
 
 ```bash
 $ sysml examples/parser_features_demo_action_semantics.sysml -convert ttl -o /tmp/action-semantics.ttl; echo $?
@@ -194,7 +188,7 @@ wrote /tmp/action-semantics.ttl (ttl, 21671 bytes)
 0
 ```
 
-For example, an advanced body with an operator expression is still refused:
+For example, an advanced body containing an operator expression is refused:
 
 ```bash
 $ sysml examples/parser_features_demo_advanced_bodies.kerml -convert ttl; echo $?

--- a/docs/guide/08-editors.md
+++ b/docs/guide/08-editors.md
@@ -1,15 +1,16 @@
 # 8. Editors
 
-`sysml-lsp` speaks LSP over stdio, so any editor with a generic LSP client can drive it. The
-VS Code extension in [editors/vscode](../../editors/vscode) adds `.sysml`/`.kerml` highlighting
-on top.
+`sysml-lsp` implements the Language Server Protocol over standard input and output, so any editor
+with a generic LSP client can use it. The VS Code extension in
+[editors/vscode](../../editors/vscode) additionally provides `.sysml` and `.kerml` syntax
+highlighting.
 
 ## VS Code
 
-This repository ships its own VS Code extension in
-[editors/vscode](../../editors/vscode): syntax highlighting for `.sysml` and
-`.kerml` plus an LSP client that launches `sysml-lsp`. It is not published to any
-marketplace, so build and side-load it:
+This repository provides a VS Code extension in [editors/vscode](../../editors/vscode), offering
+syntax highlighting for `.sysml` and `.kerml` together with an LSP client that launches
+`sysml-lsp`. The extension is not published to any marketplace, so it must be built and
+side-loaded:
 
 ```bash
 make build                                    # builds bin/sysml-lsp
@@ -19,15 +20,15 @@ npm run package                               # -> opensysml-sysml.vsix
 code --install-extension opensysml-sysml.vsix
 ```
 
-Open any `.sysml` file: it is highlighted immediately, and the extension starts
-the server it finds, in order:
+Opening any `.sysml` file highlights it immediately, and the extension starts the first server it
+finds, searching in the following order:
 
 1. `opensysml.server.path`, if set;
 2. `bin/sysml-lsp` inside an open workspace folder (a checkout that ran `make build`);
 3. `sysml-lsp` on `PATH`.
 
-If no server is found, highlighting still works and a warning explains how to
-build one. Point the extension at a specific build with `.vscode/settings.json`:
+If no server is found, highlighting continues to work and a warning explains how to build one. To
+direct the extension at a specific build, use `.vscode/settings.json`:
 
 ```json
 {
@@ -36,13 +37,13 @@ build one. Point the extension at a specific build with `.vscode/settings.json`:
 }
 ```
 
-### Asking the strict question in the editor
+### Strict conformance in the editor
 
-The server reports OpenSysML's own notation as warnings, like the CLI does. An
-editor that can send settings asks the strict question with the boolean
+As on the command line, the server reports OpenSysML's own notation extensions as warnings. An
+editor that can send settings enables strict conformance with the boolean
 `sysml.strictConformance` ([LSP extensions](../reference/lsp.md#strict-conformance-setting)),
-and the diagnostics of every open document are republished as errors at once. In
-this extension, start the server strictly instead:
+after which the diagnostics of every open document are republished as errors. In this extension,
+start the server in strict mode instead:
 
 ```json
 {
@@ -52,42 +53,38 @@ this extension, start the server strictly instead:
 
 ### The diagram panel
 
-`SysML: Open Diagram`, from the command palette with a `.sysml` or `.kerml` file
-open, puts a diagram of the model beside the editor. It draws the same
-renderings the REPL's `%view` prints, as Mermaid, and it redraws as the model is
-typed.
+Running `SysML: Open Diagram` from the command palette with a `.sysml` or `.kerml` file open
+displays a diagram of the model beside the editor. The panel draws the same renderings that the
+REPL's `%view` command prints, using Mermaid, and redraws as the model is edited.
 
-- **What it draws.** The view the document declares, picked from the dropdown
-  when it declares several, or — the usual case for a model being written — the
-  document itself, as a tree, an interconnection diagram, a state diagram, an
-  action flow, a sequence diagram or a table. A view whose rendering is not
-  supported (`geometry`, `textual`) stays in the picker, saying why it cannot be
-  drawn.
-- **Click a node** to jump to the declaration it was built from; move the cursor
-  in the editor and the node containing it is highlighted. A node with no
-  locatable declaration — a standard library symbol — is not clickable.
-- **While typing.** A keystroke that leaves the model unparseable dims the last
-  good diagram and puts the error in the status line under it; the panel never
-  blanks. What the rendering could not represent is listed under the diagram.
-- **Cost.** The panel asks for a diagram only while it is visible, and only once
-  an editing burst settles. Mermaid is bundled into the extension, so nothing is
-  fetched from the network.
+- **Content.** The panel draws the view the document declares, selected from a dropdown when the
+  document declares several, or, as is usual for a model under development, the document itself,
+  rendered as a tree, an interconnection diagram, a state diagram, an action flow, a sequence
+  diagram or a table. A view whose rendering is unsupported (`geometry`, `textual`) remains in the
+  picker and reports why it cannot be drawn.
+- **Navigation.** Clicking a node jumps to the declaration it was built from, and moving the
+  cursor in the editor highlights the node containing it. A node with no locatable declaration,
+  such as a standard library symbol, is not clickable.
+- **Behavior while editing.** A keystroke that leaves the model unparseable dims the last valid
+  diagram and reports the error in the status line beneath it; the panel is never blanked.
+  Anything the rendering could not represent is listed below the diagram.
+- **Resource use.** The panel requests a diagram only while it is visible, and only after an
+  editing burst has settled. Mermaid is bundled with the extension, so nothing is fetched from the
+  network.
 
-It is read-only: it renders the model, and editing the diagram does not edit the
-model. The panel appears only when the server it is talking to serves the render
-methods ([LSP extensions](../reference/lsp.md)), so an older `sysml-lsp` simply
-does not offer the command.
+The panel is read-only: it renders the model, and editing the diagram does not modify the model.
+It is available only when the server it is connected to provides the render methods
+([LSP extensions](../reference/lsp.md)), so an older `sysml-lsp` does not offer the command.
 
-Run `SysML: Restart Language Server` from the command palette after rebuilding
-the binary. `editors/vscode/README.md` documents every setting, the grammar
-generator (keywords come from `internal/core/lexer.Keywords()`, so they cannot
-drift) and the <kbd>F5</kbd> extension-debugging loop.
+After rebuilding the binary, run `SysML: Restart Language Server` from the command palette. The
+file `editors/vscode/README.md` documents every setting, the grammar generator (keywords are taken
+from `internal/core/lexer.Keywords()`, so they cannot drift) and the <kbd>F5</kbd>
+extension-debugging loop.
 
-Other editors can still launch `bin/sysml-lsp` over stdio through their own
-generic LSP client; only the highlighting is VS Code-specific.
+Other editors can launch `bin/sysml-lsp` over standard input and output through their own generic
+LSP client; only the syntax highlighting is specific to VS Code.
 
-**What the server advertises at `initialize`** — the capabilities it answers, taken
-from a live session with `bin/sysml-lsp`:
+**Capabilities advertised at `initialize`**, recorded from a live session with `bin/sysml-lsp`:
 
 - ✅ Document synchronization, incremental (`textDocumentSync.change: 2`)
 - ✅ Diagnostics (syntax + semantic errors, published on open and on change)
@@ -112,16 +109,16 @@ from a live session with `bin/sysml-lsp`:
   unresolved name, importing the namespace that declares it, inserting a missing
   semicolon the parser located exactly)
 
-**Not implemented:** semantic token deltas (`semanticTokens/full/delta` — the
-server holds no previous result to diff against, so a client re-requests the
-full set), signature help, range formatting, code lens, inlay hints. A client
-asking for one of those gets the method-not-found answer rather than a partial
-result. Quick fixes are offered only where the repair is unambiguous: a syntax
-error that may want either a body or a semicolon carries none.
+**Not implemented:** semantic token deltas (`semanticTokens/full/delta`; the server retains no
+previous result to diff against, so clients re-request the full set), signature help, range
+formatting, code lens and inlay hints. A client that requests one of these receives a
+method-not-found response rather than a partial result. Quick fixes are offered only where the
+repair is unambiguous: a syntax error that could require either a body or a semicolon carries
+none.
 
-**Test the server:** the protocol is JSON-RPC over stdio, so a request can be sent
-by hand. Formatting a badly indented file and renaming a definition, run against
-`bin/sysml-lsp`:
+**Testing the server:** the protocol is JSON-RPC over standard input and output, so requests can
+be sent manually. The following exchange formats a badly indented file and renames a definition,
+run against `bin/sysml-lsp`:
 
 ```
 → textDocument/formatting  (file: "package P {\npart def Wheel {\nattribute diameter = 16.0;\n}\npart w : Wheel;\n}\n")
@@ -134,10 +131,10 @@ by hand. Formatting a badly indented file and renaming a definition, run against
       {"range": {"start": {"line": 4, "character": 9}, "end": {"line": 4, "character": 14}}, "newText": "Tyre"}]}}
 ```
 
-The rename edits the declaration and the `part w : Wheel` reference together —
-it is resolution-driven, not a textual replace.
+The rename edits the declaration and the `part w : Wheel` reference together, because it is
+resolution-driven rather than a textual replacement.
 
-In an editor, check the install by hovering: open a file containing
+To verify the installation in an editor, open a file containing
 `part Wheel { attribute diameter = 16.0; }` and hover over `Wheel`.
 
 ---

--- a/docs/guide/09-python.md
+++ b/docs/guide/09-python.md
@@ -1,10 +1,10 @@
 # 9. From Python
 
-`opensysml` is the Python client. Every call goes through the `sysml-grpc` service, which the
-client starts and stops for you, so a script parses, inspects, executes and converts a model
-without shelling out to `sysml`.
+`opensysml` is the Python client. Every call is made through the `sysml-grpc` service, which the
+client starts and stops automatically, so a script can parse, inspect, execute and convert a model
+without invoking `sysml` as a subprocess.
 
-The full API surface, the generated typed classes and the measured latency are
+The complete API surface, the generated typed classes and the measured latency are documented in
 [reference/python-api.md](../reference/python-api.md).
 
 ## Installation
@@ -14,56 +14,54 @@ pip install opensysml             # from PyPI
 pip install -e clients/python/          # or from a checkout, at the repository root
 ```
 
-Dependencies (`grpcio`, `protobuf>=7.35.1`, `filelock`, `psutil`) come with it.
-They publish wheels for CPython 3.10 and later only, which is what
-`requires-python` says.
+The dependencies (`grpcio`, `protobuf>=7.35.1`, `filelock`, `psutil`) are installed alongside it.
+Those projects publish wheels for CPython 3.10 and later only, which is the range declared by
+`requires-python`.
 
 ## Getting the service binary
 
-Every call goes through `sysml-grpc`. `opensysml` starts one for you and expects to
-find it at `~/.opensysml/bin/sysml-grpc`. Three ways to put it there:
+Every call is made through `sysml-grpc`. The client starts an instance of the service and expects
+to find the binary at `~/.opensysml/bin/sysml-grpc`. There are three ways to provide it:
 
 ```bash
 # 1. Download the release build (verified against the digest pinned in opensysml)
 python -c "from opensysml.binary import download_binary; download_binary('latest')"
 
-# 2. Let opensysml.connect() download it on first use
+# 2. Have opensysml.connect() download it on first use
 export OPENSYSML_GRPC_VERSION=latest      # or a tag like v0.0.5
 
 # 3. Build from source
 make build-grpc && mkdir -p ~/.opensysml/bin && cp bin/sysml-grpc ~/.opensysml/bin/
 ```
 
-Without one of those, `connect()` raises `ConnectionError` rather than
-downloading anything unasked. `OPENSYSML_GITHUB_REPO` overrides the repository
-releases are fetched from (default `Open-MBEE/OpenSysML`).
+If none of these is done, `connect()` raises `ConnectionError` rather than downloading anything
+unrequested. `OPENSYSML_GITHUB_REPO` overrides the repository releases are fetched from (default
+`Open-MBEE/OpenSysML`).
 
 A download records its release tag, repository and digest beside the binary
-(`~/.opensysml/bin/sysml-grpc.json`), so a cache left by an earlier release — or by
-another repository publishing the same tag — is replaced instead of being served
-to a client asking for a newer one; otherwise an old build answers and the call
-fails as a `MissingCapabilityError` naming a capability the requested release does
-have. Asking for a release is what
-triggers that check, so with `OPENSYSML_GRPC_VERSION` unset a binary you put there
-yourself (option 3) is left alone. If the release asked for cannot be downloaded
-(no asset for your platform, no network), the cached binary keeps serving and the
-warning says so, rather than the connection failing.
+(`~/.opensysml/bin/sysml-grpc.json`), so a cache left by an earlier release, or by another
+repository publishing the same tag, is replaced rather than served to a client requesting a newer
+one. Without this check an older build would answer and the call would fail as a
+`MissingCapabilityError` naming a capability the requested release provides. The check is
+triggered by requesting a release, so when `OPENSYSML_GRPC_VERSION` is unset a manually installed
+binary (option 3) is left untouched. If the requested release cannot be downloaded, because no
+asset exists for the platform or no network is available, the cached binary continues to serve and
+the warning reports this rather than the connection failing.
 
-A download is checked against the SHA-256 `opensysml` pins for that release, not
-the `.sha256` served beside the binary: the sidecar comes from whoever served the
-binary, so it catches corruption but not a republished release. A release this
-`opensysml` pins no digest for is refused, naming the version, and keeps a working
-cached binary rather than trusting the served checksum; `export
-OPENSYSML_ALLOW_UNPINNED_DOWNLOAD=<owner/repo>` (or `=1` for any repository, which a
-fork's releases do not need) accepts same-origin trust explicitly for the repository
-it names, with a warning. The binary is cached in `~/.opensysml/bin`; a service the
-client starts is a private child of the interpreter and keeps no state on disk, so
-`OPENSYSML_STATE_DIR`, which moved the service records only, no longer does
-anything.
+A download is verified against the SHA-256 digest that `opensysml` pins for that release, not
+against the `.sha256` served beside the binary. The sidecar file originates from whoever served
+the binary, so it detects corruption but not a republished release. A release for which this
+`opensysml` pins no digest is refused, with the version named, and a working cached binary is
+retained rather than the served checksum being trusted. Setting
+`OPENSYSML_ALLOW_UNPINNED_DOWNLOAD=<owner/repo>` (or `=1` for any repository, which is not
+required for a fork's releases) explicitly accepts same-origin trust for the repository named,
+with a warning. The binary is cached in `~/.opensysml/bin`. A service started by the client is a
+private child of the interpreter and retains no state on disk, so `OPENSYSML_STATE_DIR`, which
+previously relocated the service records, no longer has any effect.
 
-The published releases up to v0.0.4 carry the `sysml`/`sysml-lsp` archives only;
-`sysml-grpc` binaries are published from the next release onward, so until then
-build it from source (option 3).
+Releases up to v0.0.4 contain the `sysml` and `sysml-lsp` archives only. `sysml-grpc` binaries are
+published from the following release onward; until then, build the service from source
+(option 3).
 
 ## A first script
 
@@ -77,20 +75,20 @@ for d in model.diagnostics:
 print(model.eval("1 + 2 * 3"))
 ```
 
-Evaluation is on the model, like every other operation, so a script never carries
-the model hash back to the connection. `model.eval(expr, context_symbol_id=…)`
-resolves the expression's names in that element's scope.
+Evaluation is performed on the model, as is every other operation, so a script never has to carry
+the model hash back to the connection. `model.eval(expr, context_symbol_id=…)` resolves the
+expression's names in that element's scope.
 
-## Loading a model that has to be usable
+## Requiring a usable model
 
-A model with syntax errors still parses to a `Model` — the service reports what
-it could read plus diagnostics — so a script that does not look at them queries a
-model that is missing declarations. Ask for a valid one instead:
+A model containing syntax errors still parses to a `Model`, because the service reports what it
+could read together with diagnostics. A script that does not inspect those diagnostics therefore
+queries a model that is missing declarations. To require a valid model instead:
 
 ```python
 model = opensysml.load("model.sysml")
 model.ok                       # False when any diagnostic is an error
-model.errors                   # just the error-severity diagnostics
+model.errors                   # only the error-severity diagnostics
 model.raise_for_errors()       # raises ModelError, or returns the model
 
 model = opensysml.load("model.sysml", strict=True)   # raises instead of returning
@@ -110,30 +108,28 @@ except opensysml.ModelError as exc:
     partial = exc.model            # what the service did parse
 ```
 
-`strict_conformance=True`, on the same three calls, asks a different question:
-whether the source is conforming SysML v2. OpenSysML's own notation — `defer`,
-the pseudostates — is then reported as an error rather
-than a warning
-([3. Strict conformance](03-command-line.md#strict-conformance)). The two are
-independent: `strict` decides whether errors raise, `strict_conformance` decides
-what counts as one.
+`strict_conformance=True`, available on the same three calls, addresses a different question:
+whether the source is conforming SysML v2. OpenSysML's own notation, such as `defer` and the
+pseudostates, is then reported as an error rather than a warning
+([3. Strict conformance](03-command-line.md#strict-conformance)). The two settings are
+independent: `strict` determines whether errors raise, and `strict_conformance` determines what
+constitutes an error.
 
 ```python
 model = opensysml.load("model.sysml", strict_conformance=True)
 model.ok                       # False if the model uses OpenSysML notation
 ```
 
-A service too old to know the field raises `MissingCapabilityError` instead of
-silently answering the default question; it advertises
-`strict_conformance` in `Connection.server_info().capabilities`.
+A service that predates the field raises `MissingCapabilityError` rather than silently answering
+the default question. Support is advertised as `strict_conformance` in
+`Connection.server_info().capabilities`.
 
 ## Inspecting symbols
 
-`Model.find` takes a **short** name and searches the symbol tree, returning
-`None` when there is no such symbol. `model["Vehicle"]` is the raising
-counterpart: it names the symbol that is missing, where chaining off `find`'s
-`None` would fail one call later as `AttributeError: 'NoneType' object has no
-attribute 'attributes'`.
+`Model.find` takes a **short** name and searches the symbol tree, returning `None` when no such
+symbol exists. `model["Vehicle"]` is the raising counterpart: it names the missing symbol, whereas
+chaining from `find`'s `None` would fail one call later with `AttributeError: 'NoneType' object
+has no attribute 'attributes'`.
 
 ```python
 vehicle = model["Vehicle"]        # SymbolNotFoundError if absent; also a KeyError
@@ -146,11 +142,10 @@ model.find("Nope")                # None — for asking whether a symbol exists
 model["Vehcile"]                  # SymbolNotFoundError: ... did you mean 'Vehicle'?
 ```
 
-The subscript takes a short name or an FQN. `model.get("Demo::Vehicle")` looks a
-symbol up by fully-qualified name only, and returns `None` for a name it does not
-find.
+The subscript accepts a short name or a fully-qualified name. `model.get("Demo::Vehicle")` looks a
+symbol up by fully-qualified name only and returns `None` for a name it does not find.
 
-A symbol also carries its static type facts, resolved by the service:
+A symbol also carries its static type facts, as resolved by the service:
 
 ```python
 engine = model.get("Demo::Vehicle::engine")
@@ -161,8 +156,8 @@ engine.specializations   # [Specialization(kind='typing', target_id='Demo::Engin
 
 ## Instances
 
-Feature values come back as Python values, and a feature value holding an object
-comes back as a nested `Instance`:
+Feature values are returned as Python values, and a feature value holding an object is returned as
+a nested `Instance`:
 
 ```python
 inst = model.instantiate("Demo::Vehicle")
@@ -175,35 +170,34 @@ inst.features             # {'mass': 1500.0, 'engine': Instance(...)}
 inst.get("missing", 0)    # 0
 ```
 
-Integers, reals, booleans, strings and sequences map to `int`, `float`, `bool`,
-`str` and `list`. Unknown names raise `AttributeError` (attribute access) or
-`KeyError` (item access), so `hasattr`, `copy` and `pickle` behave.
+Integers, reals, booleans, strings and sequences map to `int`, `float`, `bool`, `str` and `list`.
+Unknown names raise `AttributeError` for attribute access or `KeyError` for item access, so
+`hasattr`, `copy` and `pickle` behave as expected.
 
-A feature value holding nothing — a valueless feature of a value type, `attribute d : Real;` —
-reads as `opensysml.UNSET`, the same thing `%features` and `-instantiate` spell `<unset>`. It
-is falsy and is not `None`, which stays the model's `null`:
+A feature value holding nothing, such as a valueless feature of a value type declared
+`attribute d : Real;`, reads as `opensysml.UNSET`, which `%features` and `-instantiate` render as
+`<unset>`. It is falsy and is not `None`, which continues to represent the model's `null`:
 
 ```python
 inst.d is opensysml.UNSET   # True
 inst.d is None            # False
 ```
 
-The service expands the object graph to depth 8 and stops at a type already on
-the path, so a part containing its own kind terminates; a child it did not
-expand comes back as its bare integer id rather than an `Instance`.
+The service expands the object graph to depth 8 and stops at a type already present on the path,
+so a part containing its own kind terminates. A child that was not expanded is returned as its
+bare integer id rather than as an `Instance`.
 
-The raw protobuf stays reachable: `get_feature(name)` returns the `FeatureValue`
-message, and `raw_features` is the whole map.
+The raw protobuf remains accessible: `get_feature(name)` returns the `FeatureValue` message, and
+`raw_features` is the complete map.
 
 ```python
 inst.get_feature("mass").materialized         # True
 inst.get_feature("engine").value.instance_id  # 2
 ```
 
-A feature value the service could not evaluate — a cyclic derived attribute, say — is
-never reported as `None`. Attribute and item access raise `FeatureValueError`, while
-`features` carries the `FeatureValueError` as that entry's value so the rest of the
-instance stays inspectable.
+A feature value the service could not evaluate, such as a cyclic derived attribute, is never
+reported as `None`. Attribute and item access raise `FeatureValueError`, while `features` carries
+the `FeatureValueError` as that entry's value so the remainder of the instance stays inspectable.
 
 ```python
 cyclic.a               # raises FeatureValueError: feature value 'a': ... cyclic feature value dependency
@@ -211,16 +205,16 @@ cyclic.features["a"]   # FeatureValueError(...)
 ```
 
 `FeatureValueError` is not an `AttributeError`, so `hasattr` on such a feature propagates it
-rather than returning `False`; use `features` to inspect an instance whose feature values may
-have failed.
+rather than returning `False`. Use `features` to inspect an instance whose feature values may have
+failed to evaluate.
 
 `eval` returns a single value, so a result the wire format cannot represent raises
 `UnsupportedValueError` rather than being reported per entry.
 
-Instances are negotiated like conversion: a service too old to report the
-`feature_values` capability — every release published before 0.1.0 — raises
-`MissingCapabilityError` naming the upgrade, rather than handing back an object
-whose values all appear to be missing.
+Instances are capability-negotiated in the same way as conversion: a service that does not report
+the `feature_values` capability, which applies to every release published before 0.1.0, raises
+`MissingCapabilityError` naming the required upgrade rather than returning an object whose values
+all appear to be missing.
 
 Actions and state machines run on the model too:
 
@@ -233,17 +227,16 @@ model.execute_state("Demo::Machine", events=["go"])            # {'states_visite
 a value the wire format cannot represent is reported as an
 `UnsupportedValueError` in that entry, leaving the other entries intact.
 
-Every call about a loaded model is a `Model` method, and the module-level
-`opensysml.instantiate`/`evaluate`/`convert` remain for instantiating straight out of a
-file (`opensysml.instantiate("Demo::Vehicle", file_path="model.sysml")`) or against
-a hash obtained elsewhere (`model_hash=…`).
+Every call concerning a loaded model is a `Model` method. The module-level
+`opensysml.instantiate`, `opensysml.evaluate` and `opensysml.convert` remain available for
+instantiating directly from a file (`opensysml.instantiate("Demo::Vehicle",
+file_path="model.sysml")`) or against a hash obtained elsewhere (`model_hash=…`).
 
 ## Verifying constraints, requirements, satisfaction and calculations
 
-The questions the REPL answers with `%constraint`, `%requirement`, `%satisfy` and
-`%calc` are RPCs too, so "does this model satisfy its requirements?" is
-scriptable. They run the same runtime evaluation the REPL drives, not a second
-implementation of it.
+The checks the REPL performs with `%constraint`, `%requirement`, `%satisfy` and `%calc` are also
+available as RPCs, so whether a model satisfies its requirements can be determined from a script.
+These calls use the same runtime evaluation the REPL drives rather than a second implementation.
 
 ```python
 model = opensysml.load("lander.sysml", strict=True)
@@ -258,16 +251,15 @@ model.satisfied()                                  # False — one assertion fai
 model.verify_satisfaction("Landing::analysisContext")   # only what that element asserts
 ```
 
-Constraints and requirements are asked about by name, optionally against a
-subject to instantiate, so the verdict is about that object's values rather than
-declared defaults:
+Constraints and requirements are named directly, optionally with a subject to instantiate, so that
+the verdict concerns that object's values rather than declared defaults:
 
 ```python
 model.verify_constraint("Demo::Vehicle::massOK", subject="Demo::sedan")
 model.verify_requirement("Demo::Vehicle::lightEnough", subject="Demo::sedan")
 ```
 
-A `Verdict` is truthy when the condition holds, and carries why when it does not:
+A `Verdict` is truthy when the condition holds, and reports the reason when it does not:
 
 ```python
 verdict = model.verify_requirement("Demo::Vehicle::lightEnough", subject="Demo::truck")
@@ -283,12 +275,12 @@ verdict.diagnostics    # diagnostics the service reported for the run
 print(verdict.explain())
 ```
 
-**A false verdict is an answer, not an exception.** A condition that evaluated to
-false is what was asked, so it is returned; only a failure to evaluate at all (an
-unbound feature, an exhausted step budget) is a malfunction. That failure does
-not masquerade as a failing verdict either — it is `verdict.error`, with
-`verdict.evaluated` False, and `verdict.raise_for_error()` turns it into an
-`ExecutionError` where a script must not read it as "the requirement fails":
+**A false verdict is a result, not an exception.** A condition that evaluated to false is the
+answer to the question asked, so it is returned. Only a failure to evaluate at all, such as an
+unbound feature or an exhausted step budget, constitutes a malfunction, and such a failure is not
+reported as a failing verdict. It appears as `verdict.error` with `verdict.evaluated` set to
+`False`, and `verdict.raise_for_error()` converts it into an `ExecutionError` where a script must
+not interpret it as a failed requirement:
 
 ```python
 for verdict in model.verify_satisfaction():
@@ -297,18 +289,16 @@ for verdict in model.verify_satisfaction():
         print(verdict.explain())
 ```
 
-A request that cannot be answered at all — an unknown symbol, a subject that
-cannot be instantiated — raises `ExecutionError` from the call itself rather than
-returning a verdict. Narrowing to an element that states no satisfaction
-assertion is not such a request: it answers with no verdicts, and `satisfied()`
-is then vacuously `True`.
+A request that cannot be answered at all, such as one naming an unknown symbol or a subject that
+cannot be instantiated, raises `ExecutionError` from the call itself rather than returning a
+verdict. Narrowing to an element that states no satisfaction assertion is not such a request: it
+returns no verdicts, and `satisfied()` is then vacuously `True`.
 
-**Naming the wrong kind of element is a wrong request, not a verdict.** Asking
-whether a part def holds as a constraint raises `WrongKindError` (an
-`ExecutionError`) from `verify_constraint`, `verify_requirement`,
-`verify_satisfaction` and `calc`, as naming an element that does not exist
-already does — so a caller reading `.holds` is never told "your model does not
-hold" when the answer is "you named a part def":
+**Naming an element of the wrong kind is an invalid request, not a verdict.** Requesting whether a
+part def holds as a constraint raises `WrongKindError`, a subclass of `ExecutionError`, from
+`verify_constraint`, `verify_requirement`, `verify_satisfaction` and `calc`, exactly as naming a
+nonexistent element does. A caller reading `.holds` is therefore never told that the model does
+not hold when the actual problem is that a part def was named:
 
 ```python
 model.verify_constraint("Demo::Wheel")
@@ -316,36 +306,34 @@ model.verify_constraint("Demo::Wheel")
 # not a constraint definition or usage
 ```
 
-The kind is read from a typed `failure_reason` the service reports, never from
-the message text.
+The kind is read from a typed `failure_reason` reported by the service, never from the message
+text.
 
-`verify_satisfaction` answers many assertions in one call and reports one object
-graph for them all, so `verdict.instances` holds every object that call built;
-select the one a verdict is about with its `instance_id`:
+`verify_satisfaction` evaluates many assertions in one call and reports a single object graph for
+all of them, so `verdict.instances` holds every object that the call built. Select the object a
+verdict concerns using its `instance_id`:
 
 ```python
 subject = next(i for i in verdict.instances if i.id == verdict.instance_id)
 ```
 
-Calculations are invoked with positional arguments, and a calc *usage* named with
-no arguments is evaluated from its own members, reporting every output feature it
-computes (SysML 7.17):
+Calculations are invoked with positional arguments. A calc *usage* named without arguments is
+evaluated from its own members and reports every output feature it computes (SysML 7.17):
 
 ```python
 model.calc("Demo::add", arguments=[2.5, 4.0]).value    # 6.5
 model.calc("Demo::c").outputs                          # {'a': 6, 'b': 10}
 ```
 
-Verification is negotiated like conversion: against a service too old to report
-the `verification` capability these calls raise `MissingCapabilityError` naming
-the upgrade, rather than failing on an unimplemented method.
+Verification is capability-negotiated in the same way as conversion: against a service that does
+not report the `verification` capability, these calls raise `MissingCapabilityError` naming the
+required upgrade rather than failing on an unimplemented method.
 
 ## Errors
 
-Every failure a caller can act on is a `OpenSysMLError`. The service's gRPC status
-codes are translated at the client boundary, so a script never has to `import
-grpc` and switch on status codes; the original `grpc.RpcError` stays reachable as
-`__cause__` for the debug string.
+Every failure a caller can act on is an `OpenSysMLError`. The service's gRPC status codes are
+translated at the client boundary, so a script never needs to `import grpc` and switch on status
+codes. The original `grpc.RpcError` remains accessible as `__cause__` for its debug string.
 
 ```
 OpenSysMLError
@@ -371,55 +359,52 @@ OpenSysMLError
 └── MissingCapabilityError     the connected service does not report the capability
 ```
 
-`ServiceError.code` is the `grpc.StatusCode` behind it. A status this client has
-never seen still arrives as a `ServiceError`, so nothing escapes the hierarchy.
+`ServiceError.code` is the underlying `grpc.StatusCode`. A status this client does not recognize
+is still delivered as a `ServiceError`, so nothing escapes the hierarchy.
 
-The two most common failures are both `NOT_FOUND` on the wire but have different
-fixes, and are told apart from what the service reports:
+The two most common failures are both `NOT_FOUND` on the wire but require different remedies, and
+are distinguished from what the service reports:
 
 ```python
 opensysml.load("/tmp/nope.sysml")     # ModelFileNotFoundError: file not found: …
 model.to_turtle()                   # ModelNotFoundError if the model was evicted
 ```
 
-`ExecutionError` inherits from the built-in `RuntimeError`, so `except
-RuntimeError:` catches it — which is what a traceback reading
-`opensysml.errors.RuntimeError` used to promise and not deliver. That old name
-remains as a deprecated alias of `ExecutionError` (same class, so existing
-`except opensysml.errors.RuntimeError` keeps working) and emits a
-`DeprecationWarning` on attribute access. Inheriting from the built-in was chosen
-over renaming alone because it fixes existing code that never caught the old
-class, and the alias is excluded from `__all__` so a star-import no longer
-shadows the built-in.
+`ExecutionError` inherits from the built-in `RuntimeError`, so `except RuntimeError:` catches it,
+which a traceback reading `opensysml.errors.RuntimeError` previously implied but did not deliver.
+The former name remains as a deprecated alias of `ExecutionError` — it is the same class, so
+existing `except opensysml.errors.RuntimeError` clauses continue to work — and emits a
+`DeprecationWarning` on attribute access. Inheriting from the built-in was chosen over renaming
+alone because it also corrects existing code that never caught the old class, and the alias is
+excluded from `__all__` so a star-import no longer shadows the built-in.
 
 ### Names that no longer shadow a built-in
 
-Both names the package used to bind over a Python built-in were renamed before
-0.2.0 published, so no deprecation cycle is owed:
+Both names that the package previously bound over a Python built-in were renamed before 0.2.0 was
+published, so no deprecation cycle is required:
 
 | Old name | Use instead |
 | --- | --- |
 | `opensysml.eval` | `opensysml.evaluate` |
 | `opensysml.RuntimeError`, `opensysml.errors.RuntimeError` | `opensysml.ExecutionError` |
 
-Each old name still resolves to the same object — `opensysml.eval` *is*
-`opensysml.evaluate` and `opensysml.RuntimeError` *is* `ExecutionError`, so existing
-snippets and `except` clauses keep working — and emits a `DeprecationWarning` on
-access. Neither is in `__all__`, so `from opensysml import *` no longer binds over
-`eval` or `RuntimeError`. The `Model.eval`/`Connection.eval` *methods* keep their
-name: an attribute of an object shadows nothing.
+Each former name still resolves to the same object — `opensysml.eval` *is* `opensysml.evaluate`
+and `opensysml.RuntimeError` *is* `ExecutionError`, so existing snippets and `except` clauses
+continue to work — and emits a `DeprecationWarning` on access. Neither appears in `__all__`, so
+`from opensysml import *` no longer binds over `eval` or `RuntimeError`. The `Model.eval` and
+`Connection.eval` *methods* retain their name, because an attribute of an object shadows nothing.
 
 ## Writing a model back out
 
-A loaded model can be written back to SysML notation or RDF Turtle. The service
-does the conversion with the same code `sysml -convert` uses, so the client adds
-no second implementation of the mapping.
+A loaded model can be written back to SysML notation or RDF Turtle. The service performs the
+conversion using the same code as `sysml -convert`, so the client contributes no second
+implementation of the mapping.
 
-The Turtle direction is [experimental](../reference/rdf-mapping.md#status-experimental):
-it carries model structure and the behavior its bodies state, refuses what it
-cannot write back, and its vocabulary may change without a compatibility path.
-Any conversion through it warns with `ExperimentalFeatureWarning` and sets
-`Conversion.experimental`; notation is stable and warns about nothing.
+The Turtle direction is [experimental](../reference/rdf-mapping.md#status-experimental): it
+carries model structure and the behavior stated by model bodies, refuses any construct it cannot
+write back, and its vocabulary may change without a compatibility path. Any conversion using it
+issues an `ExperimentalFeatureWarning` and sets `Conversion.experimental`. The notation direction
+is stable and issues no warning.
 
 ```python
 model = opensysml.load("model.sysml")
@@ -433,49 +418,45 @@ opensysml.convert("ttl", file_path="model.sysml")            # without loading f
 opensysml.convert("sysml", content=turtle, from_format="ttl")  # Turtle back to notation
 ```
 
-A `Conversion` is the output text plus the formats it went between, and whether
-the mapping it used is `experimental` (with `experimental_notice` saying why);
-`str()` and `len()` give the text, and `write(path)` saves it. Formats are named `sysml`,
-`kerml`, `text`, `ttl`, `turtle` or `rdf`. A file path's format is inferred from
-its extension; inline `content` has no extension, so it needs `from_format`.
+A `Conversion` consists of the output text, the formats converted between, and whether the mapping
+used is `experimental`, with `experimental_notice` explaining why. `str()` and `len()` return the
+text, and `write(path)` saves it. Formats are named `sysml`, `kerml`, `text`, `ttl`, `turtle` or
+`rdf`. A file path's format is inferred from its extension; inline `content` has no extension and
+therefore requires `from_format`.
 
-A `Model` writes out the source the service parsed, named by `model.hash`, so a
-file edited between `load` and `save` does not change what is written — the model
-saved is the model that was inspected. `convert(file_path=…)` is the other
-choice, reading the file as it stands now. The parsed source lives in the
-service's bounded cache, so a model evicted since it was loaded raises
-`ModelNotFoundError` instead of writing something else; load it again.
+A `Model` writes out the source the service parsed, identified by `model.hash`, so a file edited
+between `load` and `save` does not affect what is written: the model saved is the model that was
+inspected. `convert(file_path=…)` is the alternative, reading the file in its current state. The
+parsed source is held in the service's bounded cache, so a model evicted since it was loaded
+raises `ModelNotFoundError` rather than writing different content; load it again.
 
-What each direction preserves:
+Each direction preserves the following:
 
-- **Notation → notation** re-emits the model from its source, so comments and
-  layout survive. It is source-preserving, not a general AST printer: a model
-  the client built element by element cannot be printed this way.
-- **Notation → Turtle → notation** returns an equivalent model, not identical
-  bytes. Comments do not survive the graph, since RDF has nowhere to keep them.
-  See [the RDF mapping](../reference/rdf-mapping.md) for what a graph must carry
-  for the round trip back.
-- Syntax errors normally fail the conversion and come back as a
-  `ConversionError` carrying `diagnostics`. `tolerate_syntax_errors=True` writes
-  notation anyway and reports the errors as `Conversion.diagnostics`; it applies
-  to notation → notation only, because every other direction builds a graph
-  where an unparsed declaration would silently go missing.
+- **Notation → notation** re-emits the model from its source, so comments and layout are
+  preserved. It is source-preserving rather than a general AST printer, so a model the client
+  built element by element cannot be printed this way.
+- **Notation → Turtle → notation** returns an equivalent model rather than identical bytes.
+  Comments do not survive the graph, because RDF provides no place to record them. See
+  [the RDF mapping](../reference/rdf-mapping.md) for the content a graph must carry to support the
+  return trip.
+- Syntax errors normally fail the conversion and are returned as a `ConversionError` carrying
+  `diagnostics`. `tolerate_syntax_errors=True` writes notation regardless and reports the errors
+  as `Conversion.diagnostics`. It applies to the notation → notation direction only, because every
+  other direction builds a graph in which an unparsed declaration would be silently omitted.
 
-Conversion is negotiated: against a service too old to report the `convert`
-capability, these calls raise `MissingCapabilityError` naming the upgrade rather
-than failing on an unimplemented method. A service too old to report the RDF
-mapping's status is read from the formats it reports instead, so an RDF
-conversion warns either way. Silence the warning with
-`warnings.simplefilter("ignore", opensysml.ExperimentalFeatureWarning)`, which no
-stable feature uses.
+Conversion is capability-negotiated: against a service that does not report the `convert`
+capability, these calls raise `MissingCapabilityError` naming the required upgrade rather than
+failing on an unimplemented method. For a service that does not report the RDF mapping's status,
+the status is derived from the formats it reports, so an RDF conversion warns in either case.
+Suppress the warning with `warnings.simplefilter("ignore",
+opensysml.ExperimentalFeatureWarning)`, which no stable feature uses.
 
 ## Changing a model and writing it back
 
-A loaded model can be edited in place — the value of a feature set, a declaration
-renamed — and written back with its comments, blank lines and indentation intact.
-The edit is described, not typed out: the client sends operations naming elements
-by the same ids a read reports, and the service applies them to the source it
-parsed.
+A loaded model can be edited in place — setting the value of a feature, renaming a declaration —
+and written back with its comments, blank lines and indentation intact. The edit is described
+rather than typed out: the client sends operations naming elements by the same ids that a read
+reports, and the service applies them to the source it parsed.
 
 ```python
 model = opensysml.load("spacecraft.sysml")
@@ -488,14 +469,13 @@ result = edit.apply()             # re-parsed and validated service-side
 result.save("spacecraft.sysml")   # every byte outside an edited span unchanged
 ```
 
-`model.edit()` returns an `Editor`. `set_value(target, value)` replaces an
-existing `= <expr>` on a feature, or adds one before the terminating `;` when the
-feature has none; `value` is SysML notation for one expression — `"1050.0[SI::kg]"`,
-`'"flight-2"'`, `"true"`, `"unitMass * count"`. `rename(target, new_name)` rewrites
-a declaration's name token and the references to it. A target is a symbol id (its FQN, as `Symbol.id`
-reports it) or a `Symbol` itself, so an element found by a read is edited by
-handing it back. Both calls return the editor, so operations chain, and `len(edit)`
-counts them.
+`model.edit()` returns an `Editor`. `set_value(target, value)` replaces an existing `= <expr>` on
+a feature, or adds one before the terminating `;` when the feature has none; `value` is SysML
+notation for a single expression, such as `"1050.0[SI::kg]"`, `'"flight-2"'`, `"true"` or
+`"unitMass * count"`. `rename(target, new_name)` rewrites a declaration's name token and the
+references to it. A target is a symbol id (its fully-qualified name, as reported by `Symbol.id`)
+or a `Symbol` itself, so an element located by a read can be edited by passing it back. Both calls
+return the editor, so operations can be chained, and `len(edit)` counts them.
 
 The same editor authors declarations:
 
@@ -504,31 +484,29 @@ model = opensysml.loads("package Demo {}", strict=True)
 result = model.edit().add_part_def("", "Vehicle").apply()
 ```
 
-`add_member(owner, kind, name, type=None, multiplicity=None, value=None,
-specializes=None)` accepts notation strings for the declaration. Typed
-`add_*` helpers cover the common SysML and KerML kinds, and
-`delete(target, cascade=False)` removes declarations transactionally.
+`add_member(owner, kind, name, type=None, multiplicity=None, value=None, specializes=None)`
+accepts notation strings for the declaration. Typed `add_*` helpers cover the common SysML and
+KerML kinds, and `delete(target, cascade=False)` removes declarations transactionally.
 
-`apply()` sends the operations in one call and returns an `EditResult`, which *is*
-a `Conversion`: `str(result)` is the edited notation, `result.save(path)` and
-`result.write(path)` write it. `result.applied` lists what changed, as
-`AppliedEdit(operation_index, target, offset, length, old_text, new_text)` in
-source order — `length == 0` marks a value added to a feature that had none.
+`apply()` sends the operations in a single call and returns an `EditResult`, which *is* a
+`Conversion`: `str(result)` is the edited notation, and `result.save(path)` and
+`result.write(path)` write it. `result.applied` lists the changes as
+`AppliedEdit(operation_index, target, offset, length, old_text, new_text)` in source order, where
+`length == 0` marks a value added to a feature that previously had none.
 
-How the edit is made, and what that buys:
+The edit mechanism provides the following properties:
 
-- **Spans, not search.** The value expression and the name token are located
-  through the parsed model's own spans, so a comment or a string that happens to
-  contain the same text is never touched.
-- **Bytes are spliced, nothing is reformatted.** Edits apply right-to-left by
-  offset in one pass, and every byte outside an edited span is byte-identical to
-  the source the service parsed. Nothing is re-indented or re-wrapped.
-- **The result is read back before it is returned.** The edited source is
-  re-lexed, re-parsed and re-analysed. An edit that would introduce a syntax or
-  name-resolution error is refused with the diagnostics that say why, and no
-  content comes back — the service never hands out a file its parser cannot read.
-  Errors the model already had are not held against the edit: only what the edit
-  introduces refuses it.
+- **Spans rather than text search.** The value expression and the name token are located through
+  the parsed model's own spans, so a comment or string that happens to contain the same text is
+  never modified.
+- **Bytes are spliced and nothing is reformatted.** Edits are applied right-to-left by offset in a
+  single pass, and every byte outside an edited span is byte-identical to the source the service
+  parsed. No content is re-indented or re-wrapped.
+- **The result is read back before it is returned.** The edited source is re-lexed, re-parsed and
+  re-analysed. An edit that would introduce a syntax or name-resolution error is refused with the
+  diagnostics explaining why, and no content is returned, so the service never emits a file its
+  parser cannot read. Errors the model already contained are not attributed to the edit; only
+  errors the edit introduces cause a refusal.
 
 Every refusal is a typed error, never a silent no-op:
 
@@ -541,11 +519,11 @@ Every refusal is a typed error, never a silent no-op:
 | Two operations that would edit overlapping bytes | `OverlappingEditsError` |
 | The edited model does not read back cleanly — a value naming something that does not resolve, say | `EditResultError` |
 
-All of them are `EditError`, which carries `failure` (the refusal kind),
-`diagnostics`, and `referring_elements` for a refused rename or a refused
-non-cascade delete. An `EditResultError`'s diagnostics are spanned against the
-edited text. `referring_elements` names each namespace a reference is made from,
-so it says where to look rather than which expression is at fault.
+All of these are subclasses of `EditError`, which carries `failure` (the refusal kind),
+`diagnostics`, and `referring_elements` for a refused rename or a refused non-cascade delete. An
+`EditResultError`'s diagnostics are spanned against the edited text. `referring_elements` names
+each namespace from which a reference is made, indicating where to look rather than which
+expression is at fault.
 
 ```python
 try:
@@ -554,41 +532,37 @@ except opensysml.InvalidEditError as refused:
     print(refused.failure)   # 'EDIT_FAILURE_INVALID_NAME'
 ```
 
-A rename rewrites the declaration's name token and every reference to it the
-model's source makes — a qualified name's matching segment, an alias target and
-an import — so the model still says what it said.
+A rename rewrites the declaration's name token and every reference to it made by the model's
+source — the matching segment of a qualified name, an alias target and an import — so the model
+retains its original meaning.
 
-Known limitations, by design:
+The following limitations are intentional:
 
-- **A rename is refused where it would change what a name means.** A new name
-  that already means something where the element is declared — a sibling of that
-  name, or one reached through an enclosing namespace, an import or a supertype —
-  or that already means something at one of the references being rewritten, is
-  refused: it would either be ambiguous or shadow what is already there, and
-  either way expressions you did not name would start reading the renamed
-  element. References made from another file are not rewritten, since an edit
-  sees only the source of the model it was given.
-- **A model is not built from Python.** Declarations are added to and deleted
-  from a model that is already loaded; there is no way to author one from
-  nothing, and no object facade — a declaration is described by the notation
-  arguments of an `add_*` call, not by a Python object you mutate.
-- An editor is applied **once** — it describes an edit of the model it was made
-  from, so applying it twice raises `RuntimeError`. Load the saved file and edit
-  that.
-- The parsed source lives in the service's bounded cache, so a model evicted
-  since it was loaded raises `ModelNotFoundError` rather than editing something
-  else; load it again.
+- **A rename is refused where it would change what a name means.** A new name that already has a
+  meaning where the element is declared — as a sibling of that name, or one reached through an
+  enclosing namespace, an import or a supertype — or that already has a meaning at one of the
+  references being rewritten, is refused. Such a rename would be either ambiguous or shadow an
+  existing declaration, and in either case unrelated expressions would begin resolving to the
+  renamed element. References made from another file are not rewritten, because an edit sees only
+  the source of the model it was given.
+- **A model cannot be constructed from Python.** Declarations are added to and deleted from a
+  model that is already loaded; there is no way to author one from nothing, and no object facade.
+  A declaration is described by the notation arguments of an `add_*` call rather than by a mutable
+  Python object.
+- An editor is applied **once**. It describes an edit of the model it was created from, so
+  applying it twice raises `RuntimeError`. Load the saved file and edit that instead.
+- The parsed source is held in the service's bounded cache, so a model evicted since it was loaded
+  raises `ModelNotFoundError` rather than editing different content; load it again.
 
-Editing is negotiated the way conversion is: a service too old to report the
-`apply_edits` capability raises `MissingCapabilityError` naming the upgrade,
-before any call is made.
+Editing is capability-negotiated in the same way as conversion: a service that does not report the
+`apply_edits` capability raises `MissingCapabilityError` naming the required upgrade before any
+call is made.
 
-## Querying a model the standard's way
+## Querying a model using the standard query model
 
-`model.query(...)` runs the query the **SysML v2 API & Services** standard
-defines — `scope` / `select` / `where` — so a payload written for that API works
-verbatim, which is what the API Cookbook notebooks and MATLAB System Composer's
-`executeQuery` send:
+`model.query(...)` runs the query defined by the **SysML v2 API & Services** standard, using
+`scope`, `select` and `where`, so a payload written for that API works verbatim. This is the form
+sent by the API Cookbook notebooks and by MATLAB System Composer's `executeQuery`:
 
 ```python
 model = opensysml.load("model.sysml")
@@ -606,29 +580,26 @@ model.query(
 )
 ```
 
-Each answer is a `QueryElement`: `id` (the element's qualified name), `type` (its
-metamodel type, e.g. `PartUsage`) and `properties`, the selected properties it
-has — a property an element does not have is absent rather than empty. An unnamed
-element (a `doc` note, an anonymous usage) is not answered at all: it has no
-qualified name to be identified or scoped by.
-`as_dict()` gives it back in the standard's JSON names. `scope` takes qualified
-names or the standard's `{"@id": …}` references, and considers each named element
-and everything nested inside it; an empty scope is the whole loaded model.
+Each result is a `QueryElement` consisting of `id` (the element's qualified name), `type` (its
+metamodel type, for example `PartUsage`) and `properties`, the selected properties the element
+has. A property an element does not have is absent rather than empty. An unnamed element, such as
+a `doc` note or an anonymous usage, is not returned at all, because it has no qualified name by
+which it could be identified or scoped. `as_dict()` returns the result using the standard's JSON
+names. `scope` accepts qualified names or the standard's `{"@id": …}` references and considers
+each named element together with everything nested inside it; an empty scope covers the whole
+loaded model.
 
-A payload the standard does not describe — an unknown operator, a constraint with
-no property — raises `QueryError` before anything is sent. A property the service
-does not have raises `InvalidRequestError` naming the properties that exist,
-rather than answering with nothing, and an evicted model raises
-`ModelNotFoundError`: like every other call, gRPC status codes stop at the client
-boundary. Like conversion, the query is
-negotiated: a service too old to report the `query` capability raises
-`MissingCapabilityError`.
+A payload the standard does not describe, such as one using an unknown operator or a constraint
+without a property, raises `QueryError` before anything is sent. A property the service does not
+provide raises `InvalidRequestError` naming the properties that exist rather than returning no
+results, and an evicted model raises `ModelNotFoundError`. As with every other call, gRPC status
+codes stop at the client boundary. The query is capability-negotiated in the same way as
+conversion: a service that does not report the `query` capability raises `MissingCapabilityError`.
 
-The standard's query model has **no graph traversal and no transitive closure**:
-"everything under this part" is a `scope`, and "everything specializing this
-definition" is not expressible at all. It is an interop surface, not OpenSysML's
-expressive query story — [the API reference](../reference/api.md) states exactly what is
-supported.
+The standard's query model provides **no graph traversal and no transitive closure**: "everything
+under this part" is expressed as a `scope`, while "everything specializing this definition" cannot
+be expressed at all. It is an interoperability surface rather than OpenSysML's expressive query
+facility; [the API reference](../reference/api.md) states precisely what is supported.
 
 ---
 

--- a/docs/guide/10-troubleshooting.md
+++ b/docs/guide/10-troubleshooting.md
@@ -1,46 +1,46 @@
 # 10. Troubleshooting
 
-Symptom first. Budgets and every environment variable are in
-[reference/environment.md](../reference/environment.md).
+This chapter is organized by symptom. Budgets and the complete set of environment variables are
+documented in [reference/environment.md](../reference/environment.md).
 
-**REPL doesn't show prompt:**
-- Check terminal supports readline (most Unix shells do)
-- History stored in `$XDG_STATE_HOME/sysml/history`, or `~/.sysml_history` when `XDG_STATE_HOME` is unset; an unwritable path leaves history in memory for the session
+**The REPL does not display a prompt:**
+- Confirm that the terminal supports readline (most Unix shells do)
+- History is stored in `$XDG_STATE_HOME/sysml/history`, or in `~/.sysml_history` when `XDG_STATE_HOME` is unset; an unwritable path leaves history in memory for the session
 
-**Import errors after build:**
+**Import errors after building:**
 - Run `go mod tidy`
-- Verify Go version: `go version` (need 1.25+)
+- Verify the Go version with `go version` (1.25 or later is required)
 
 **Execution stops with "limit exceeded" or "exceeded max":**
-- The run spent one of its budgets; the message names the variable that raises it (see [reference/environment.md](../reference/environment.md))
-- If the model does not terminate, the budget is reporting a real bug — raising it only delays the error
+- The run exhausted one of its budgets; the message names the variable that raises it (see [reference/environment.md](../reference/environment.md))
+- If the model does not terminate, the budget is reporting a genuine defect, and raising the budget only delays the error
 
 **`%check`/`%explain` report "no SMT solver found":**
-- Solving is an experimental extension and no solver is bundled; install z3 (or cvc5) per platform — [1. Install: installing a solver](01-install.md#installing-a-solver-optional). `brew install Open-MBEE/tap/opensysml` brings z3 with it
-- A solver installed outside `PATH` is named by `OPENSYSML_SMT`; a value naming no executable is reported rather than passed over
-- Nothing else needs a solver: `%constraint`, `%requirement` and `%satisfy` evaluate without one
+- Solving is an experimental extension and no solver is bundled; install z3 (or cvc5) for the platform in use — see [1. Install: installing a solver](01-install.md#installing-a-solver-optional). `brew install Open-MBEE/tap/opensysml` installs z3 as a dependency
+- A solver installed outside `PATH` is named by `OPENSYSML_SMT`; a value that names no executable is reported rather than ignored
+- No other command requires a solver: `%constraint`, `%requirement` and `%satisfy` evaluate without one
 
 **`%check`/`%explain`/`%configure` report "does not support a feature this query needs":**
-- The solver `OPENSYSML_SMT` names rejected a feature the query needs — the message names the feature, the solver and what was being asked of it; nothing is answered from a script the solver would not accept
-- Which feature each solver was measured to support, and how to check one of your own, is [1. Install: solver compatibility](01-install.md#solver-compatibility--pointing-the-driver-at-another-solver); z3 supports the whole subset
-- cvc5 supports every feature today's commands need except objective optimization (`(maximize …)`, a z3 extension): `%optimize` refuses on cvc5, naming the extension it lacks, while every other command works on it
+- The solver named by `OPENSYSML_SMT` rejected a feature the query requires; the message names the feature, the solver and the operation attempted. No result is reported from a script the solver would not accept
+- The features each solver was measured to support, and the procedure for testing an additional solver, are documented in [1. Install: solver compatibility](01-install.md#solver-compatibility--pointing-the-driver-at-another-solver); z3 supports the entire subset
+- cvc5 supports every feature the current commands require except objective optimization (`(maximize …)`, a z3 extension): `%optimize` refuses on cvc5, naming the missing extension, while every other command operates normally
 
 **`%check` answers `unknown`:**
-- With `Reason: the solver ran out of time`, the query needed longer than `OPENSYSML_SMT_TIMEOUT` (default `10s`); `unknown` is a verdict, never reported as `sat` or `unsat`
-- Otherwise the solver gave up on the arithmetic, and the reason it gives says so
+- With `Reason: the solver ran out of time`, the query required longer than `OPENSYSML_SMT_TIMEOUT` (default `10s`); `unknown` is a verdict in its own right and is never reported as `sat` or `unsat`
+- Otherwise the solver was unable to decide the arithmetic, and the reason it reports states this
 
 **Syntax errors:**
-- SysML v2 textual notation only (no graphical/XMI)
+- Only SysML v2 textual notation is accepted; graphical notation and XMI are not
 - Keywords are case-sensitive
-- Multiplicity goes after relationships: `part x subsets y [0..1];`
+- Multiplicity follows relationships: `part x subsets y [0..1];`
 
 ---
 
-## Getting Help
+## Getting help
 
-- **GitHub Issues:** Report bugs or request features
-- **Discussions:** Ask questions about SysML v2 usage
-- **Spec Reference:** [OMG SysML v2.1 Beta 1 Specification](https://www.omg.org/spec/SysML/2.0) (2026-07 release)
+- **GitHub Issues:** report defects or request features
+- **Discussions:** questions about SysML v2 usage
+- **Specification reference:** [OMG SysML v2.1 Beta 1 Specification](https://www.omg.org/spec/SysML/2.0) (2026-07 release)
 
 ---
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,6 +1,7 @@
 # The OpenSysML guide
 
-Read in order the first time; each chapter assumes the ones before it.
+The chapters are intended to be read in order on a first pass; each one assumes the material of
+those preceding it.
 
 1. [Install](01-install.md) — a release build, Homebrew, or from source
 2. [Your first model](02-first-model.md) — declare, instantiate, evaluate
@@ -11,12 +12,12 @@ Read in order the first time; each chapter assumes the ones before it.
 7. [Saving, and converting to RDF](07-saving-and-rdf.md) — `%save`, `-convert`, round trips
 8. [Editors](08-editors.md) — `sysml-lsp` and the VS Code extension
 9. [From Python](09-python.md) — the `opensysml` client over `sysml-grpc`
-10. [Troubleshooting](10-troubleshooting.md) — when a run stops short
+10. [Troubleshooting](10-troubleshooting.md) — diagnosing a run that stops short
 
-Python is the chapter here because it is the oldest and widest client, not the only one: Go,
-Node/TypeScript, Java and Rust reach the same engine, and [client
-libraries](../reference/clients.md) is the map of which to pick and what each covers.
+Python is covered here because it is the oldest and most complete client, not the only one. Go,
+Node/TypeScript, Java and Rust access the same engine;
+[client libraries](../reference/clients.md) describes which to select and what each covers.
 
-Looking up one thing rather than reading? The [reference](../reference/) has the CLI flags, the
-REPL commands, the environment variables, the service API, the client libraries, the Python API and
-the RDF mapping.
+For looking up a specific detail rather than reading through, the [reference](../reference/)
+documents the CLI flags, the REPL commands, the environment variables, the service API, the client
+libraries, the Python API and the RDF mapping.

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -1,7 +1,8 @@
 # Internals
 
-How it works, for someone changing the code. What the code does for a user is
-[the guide](../guide/) and [the reference](../reference/).
+Implementation documentation, intended for contributors changing the code.
+User-facing behavior is documented in [the guide](../guide/) and
+[the reference](../reference/).
 
 - **[Architecture](architecture.md)** — the pipeline, the tiers, the test contracts
 - **[Testing](testing.md)** — the test contracts each kind of change must satisfy

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -16,11 +16,11 @@ A SysML v2 and KerML 1.1 implementation delivering the integrated tooling experi
 
 ### Design Principles
 
-- **Performance:** Sub-millisecond parsing, single static binary, no JVM/Eclipse runtime
-- **Completeness:** SysML v2 textual notation support (96/96 stdlib files parse clean: 94 vendored OMG files and 2 OpenSysML extensions)
-- **Executable models:** Not just validation—runtime that instantiates, evaluates, simulates
-- **Incremental & lazy:** Parse immediately, resolve semantics on-demand (gopls/rust-analyzer precedent)
-- **Immutable AST:** All semantic state lives in side tables keyed by node/symbol
+- **Performance:** sub-millisecond parsing, a single static binary, and no JVM or Eclipse runtime
+- **Completeness:** SysML v2 textual notation support (96 of 96 standard library files parse cleanly: 94 vendored OMG files and 2 OpenSysML extensions)
+- **Executable models:** beyond validation, a runtime that instantiates, evaluates and simulates
+- **Incremental and lazy:** parse immediately and resolve semantics on demand, following the precedent set by gopls and rust-analyzer
+- **Immutable AST:** all semantic state resides in side tables keyed by node or symbol
 
 ---
 
@@ -543,7 +543,7 @@ go test -v -run TestStdlibConformance ./internal/core/libs
 - **Purpose:** Verify parser rejects malformed input gracefully
 - **Location:** `internal/core/parser/negative_test.go`
 - **Test:** `TestNegative`, one subtest per malformed input
-- **Acceptance:** Each case produces diagnostics (doesn't panic)
+- **Acceptance:** each case produces diagnostics rather than panicking
 - **Coverage:** Unclosed blocks, unexpected tokens, invalid syntax, incomplete behavioral members
 
 **Example:**
@@ -599,7 +599,7 @@ go test -v -run TestExecutionConformance ./internal/core/runtime
 ```
 
 #### 3. Golden Execution Traces
-- **Purpose:** Verify *how* execution proceeds (ordering, scheduling), not just final result
+- **Purpose:** verify *how* execution proceeds (ordering, scheduling), not only the final result
 - **Location:** `internal/core/runtime/trace_test.go`
 - **Test:** `TestExecutionTrace` compares executor traces against `.trace.golden`
 - **Determinism:** Token sorting by ID, fixed event queue tie-breaking

--- a/docs/internals/testing.md
+++ b/docs/internals/testing.md
@@ -125,7 +125,7 @@ go test -v -run TestExecutionConformance ./internal/core/runtime
 
 ### 3. Golden Execution Traces
 
-**Purpose:** Verify *how* execution proceeds (ordering, scheduling), not just final result
+**Purpose:** verify *how* execution proceeds (ordering, scheduling), not only the final result
 
 - **Test:** `TestExecutionTrace` (internal/core/runtime/)
 - **Format:** `.trace.golden` files

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,7 +1,7 @@
 # Project
 
-Where the project stands: what is implemented, what is known to be missing, and how
-a release is cut.
+The current state of the project: what is implemented, what is known to be missing, and
+how a release is produced.
 
 The conformance records below are engineering records rather than user documentation. Where one
 still uses a short internal label — a numbered development round, or an `F<n>` follow-up row — the
@@ -11,15 +11,15 @@ says so at the top.
 - **[Spec compliance](spec-compliance.md)** — faithful, approximate, or not implemented,
   rule by rule
 - **[Training examples](training-examples.md)** — the OMG corpus, adjudicated per file
-- **[Pilot corpora gate](pilot-corpora.md)** — our diagnostics on the three pinned OMG pilot
+- **[Pilot corpora gate](pilot-corpora.md)** — OpenSysML diagnostics on the three pinned OMG pilot
   corpora, ratcheted in CI
-- **[Pilot differential](pilot-differential.md)** — our diagnostics against the OMG pilot
-  implementation, advisory
+- **[Pilot differential](pilot-differential.md)** — OpenSysML diagnostics compared against the OMG
+  pilot implementation, advisory
 - **[Pilot execution referee](pilot-execution-referee.md)** — how far the pinned pilot's
   execution surface reaches, and which behavior rows it can adjudicate
 - **[Pilot Xpect expectations](pilot-xpect.md)** — the pilot's own inline `.xt` assertions as a
   declared-intent oracle, advisory
-- **[Grammar coverage](grammar-coverage.md)** — which OMG grammar productions our inputs
+- **[Grammar coverage](grammar-coverage.md)** — which OMG grammar productions the project's inputs
   exercise, on input-presence evidence, advisory
 - **[Validation adjudications](wave10-decisions.md)** — the three adjudications the validation work
   depends on, with the measurements behind them

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,14 +1,15 @@
 # Reference
 
-Looking one thing up — every flag, command, symbol and triple, and nothing about
-why. The handbook that puts them in order is [the guide](../guide/).
+Lookup documentation: every flag, command, symbol and triple, without the
+supporting rationale. [The guide](../guide/) presents the same material in
+reading order.
 
 - **[CLI](cli.md)** — every flag of `sysml`, the modes, and the exit status
 - **[REPL commands](repl-commands.md)** — every `%` command and its arguments
 - **[LSP extensions](lsp.md)** — the custom render requests `sysml-lsp` serves a diagram client
 - **[Environment variables](environment.md)** — the bounds one run may spend, and paths
 - **[Client libraries](clients.md)** — the five ways to reach the engine from a program, what each
-  covers, and which to pick
+  covers, and how to choose between them
 - **[Go packages](api.md)** — `client/opensysml` and the packages behind it, type by type
 - **[Python API](python-api.md)** — `opensysml`, its generated typed classes and latency
 - **[Service transports](service-transports.md)** — what `sysml-grpc` serves on one port, which

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -729,8 +729,8 @@ Where the standard is vague, these are the choices this implementation makes:
   operand, or an operand that is not a number is an `INVALID_ARGUMENT` error, not
   a false verdict. `*` parses as infinity, so `multiplicityUpper > 1` holds for
   an unbounded feature.
-- An element that simply *has no value* for the property fails the comparison —
-  that is a fact about the element, not a fault in the query.
+- An element that *has no value* for the property fails the comparison; this is a
+  fact about the element, not a fault in the query.
 - `inverse` negates the verdict of its own constraint, so a constraint and its
   inverse partition the scope.
 - `and`/`or` combine nested verdicts, short-circuiting once one is decisive.

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -1,22 +1,23 @@
 # Client libraries
 
-Five ways to reach OpenSysML from a program: the Go API in your own process, and four clients of
-the `sysml-grpc` service. This page is the map — which one to pick, what each covers, and what it
-deliberately does not. Each client's own README is the detailed reference, linked per section.
+OpenSysML can be reached from a program in five ways: the Go API, used in the calling process, and
+four clients of the `sysml-grpc` service. This page describes how to choose between them, what
+each covers and what each intentionally omits. Each client's own README, linked per section, is
+the detailed reference.
 
 | Surface | Reaches the engine by | Published | Full reference |
 |---|---|---|---|
 | **Go**, `client/opensysml` | in process; or Connect, to a service someone else runs | with the core (`v*` tags) | [client/opensysml/README.md](../../client/opensysml/README.md) |
-| **Python**, `opensysml` | gRPC, to a private child service or one you name | PyPI, on `opensysml-v*` tags | [Python API](python-api.md) |
-| **Node/TypeScript**, `@opensysml/client` | Connect, to a private child service, one you name, or one a browser page addresses | not yet | [clients/node/README.md](../../clients/node/README.md) |
+| **Python**, `opensysml` | gRPC, to a private child service or a named service | PyPI, on `opensysml-v*` tags | [Python API](python-api.md) |
+| **Node/TypeScript**, `@opensysml/client` | Connect, to a private child service, a named service, or one a browser page addresses | not yet | [clients/node/README.md](../../clients/node/README.md) |
 | **Java**, `io.github.open-mbee:opensysml-client` | Connect, over the JDK's own HTTP client | not yet | [clients/java/README.md](../../clients/java/README.md) |
 | **Rust**, `opensysml` | Connect, blocking, no async runtime | not yet | [clients/rust/README.md](../../clients/rust/README.md) |
 
-What each protocol is and what the service serves on one port is
-[service transports](service-transports.md); how a release of each is cut is
+The protocols and what the service serves on a single port are described in
+[service transports](service-transports.md); the release process for each client is described in
 [releasing](../project/releasing.md).
 
-## Which one
+## Choosing a client
 
 - **In a Go program: `client/opensysml`.** It links the parser, the semantic engine and the runtime
   directly, so there is no port, no child process and no serialization round trip. A Go program
@@ -27,9 +28,9 @@ What each protocol is and what the service serves on one port is
   `Query` — plus generated typed classes, Jupyter display hooks and DataFrame integration.
 - **In a browser or a Node service: `@opensysml/client`.** No native addon, and the browser entry
   point needs only `fetch` against a service that allows the page's origin.
-- **In a JVM host you do not own — an Eclipse-based tool, a Cameo plugin, a web application:
-  Java.** Its transport is `java.net.http.HttpClient`, so no gRPC, Netty or `tcnative` reaches the
-  host application.
+- **In a JVM host application the caller does not control — an Eclipse-based tool, a Cameo plugin,
+  a web application: Java.** Its transport is `java.net.http.HttpClient`, so no gRPC, Netty or
+  `tcnative` reaches the host application.
 - **In a Rust program: `opensysml`.** Blocking, with no asynchronous runtime in its default
   dependency tree, and safe to call from inside one.
 
@@ -61,8 +62,8 @@ adopted. The child is shared within its scope, which shares its parse cache: per
 Python, per thread in Node, per classloader in Java (`isolatedService(true)` opts out), per
 process in Rust. `client/opensysml` starts nothing, because in process there is nothing to start.
 
-Reaching a service you did not start is always explicit — an address argument, or
-`$OPENSYSML_SERVICE` — and closing such a connection disconnects and nothing else.
+Reaching a service the client did not start is always explicit, through an address argument or
+`$OPENSYSML_SERVICE`, and closing such a connection disconnects and does nothing further.
 
 **No orphans, and the mechanism is not an exit hook.** Each client holds the write end of the
 child's stdin pipe and never writes to it; the child exits at end of file. The kernel closes that
@@ -72,10 +73,10 @@ with a test that kills its own parent process and asserts the service is gone.
 
 ## Protobuf bodies, and JSON for debugging
 
-Every client sends protobuf bodies by default and offers JSON for `curl`-shaped debugging. That
-is a measurement, not a preference: a 468 KB response costs ~6.5 ms with a protobuf body against
-~42 ms with JSON, in `protojson` and `json_format` CPU rather than bytes on the wire — see
-[service transports](service-transports.md).
+Every client sends protobuf bodies by default and offers JSON for `curl`-based debugging. This
+reflects a measurement rather than a preference: a 468 KB response costs approximately 6.5 ms with
+a protobuf body against approximately 42 ms with JSON, in `protojson` and `json_format` CPU time
+rather than bytes on the wire. See [service transports](service-transports.md).
 
 ## Providing the service binary
 
@@ -93,8 +94,8 @@ An unresolvable binary is an error naming every way to supply one, rather than a
 
 The scenarios in [`conformance/`](https://github.com/Open-MBEE/OpenSysML/tree/main/conformance)
 are the service contract, and each client runs them **through its own public API** rather than
-through generated stubs — so "it speaks to `sysml-grpc`" is measured per language, on the same
-scenarios, comparing the same answers:
+through generated stubs, so conformance with `sysml-grpc` is measured per language, over the same
+scenarios and comparing the same results:
 
 ```bash
 make conformance             # the reference runner: gRPC, Connect, Connect-JSON
@@ -103,10 +104,10 @@ make conformance-rust
 npm --prefix clients/node run conformance -- --allow-skips
 ```
 
-The Java runner is launched from its own classpath rather than by a Maven goal — the exact two
-commands are in [clients/java/README.md](../../clients/java/README.md#conformance).
+The Java runner is launched from its own classpath rather than by a Maven goal; the two exact
+commands are given in [clients/java/README.md](../../clients/java/README.md#conformance).
 
-Each runner writes the report shape `cmd/conformance` writes, and each is checked against
-deliberate corruption — a mutated response must fail a scenario — so a runner that asserts
-nothing cannot pass. Current per-client scenario counts are in each client's README; they move as
-v1 gaps close, which is why they live beside the code rather than here.
+Each runner writes the report format produced by `cmd/conformance`, and each is checked against
+deliberate corruption — a mutated response must fail a scenario — so a runner that asserts nothing
+cannot pass. Current per-client scenario counts are given in each client's README; they change as
+v1 gaps close, which is why they are maintained beside the code rather than here.

--- a/docs/reference/grammar/README.md
+++ b/docs/reference/grammar/README.md
@@ -14,13 +14,13 @@ For reference, the official Xtext grammar files from OMG are available at:
 
 These files are licensed under Eclipse Public License 2.0 (EPL-2.0) and are not included in this repository to avoid license mixing. `./scripts/download-pilot-grammars.sh` fetches them at the pinned release into `build/pilot-grammars/` when they are needed.
 
-Which of their productions our test inputs have ever exercised is measured, on input-presence evidence rather than execution coverage, in [grammar-coverage.md](../../project/grammar-coverage.md).
+The productions exercised by this project's test inputs are measured, on input-presence evidence rather than execution coverage, in [grammar-coverage.md](../../project/grammar-coverage.md).
 
 ## Conformance Audit
 
 [conformance-audit.md](conformance-audit.md) records, with `file:line` citations
 at the pinned grammars, which words and constructs OpenSysML accepts are standard
-(silent), which are our own extensions (warned as `nonstandard-notation`), and
+(silent), which are OpenSysML extensions (warned as `nonstandard-notation`), and
 which are KerML-only in a `.sysml` file (warned as `kerml-notation`).
 
 ## State Machine Notation Beyond the OMG Grammar

--- a/docs/reference/grammar/conformance-audit.md
+++ b/docs/reference/grammar/conformance-audit.md
@@ -1,10 +1,10 @@
 # Grammar Conformance Audit — reserved words and state/action notation
 
 This is the reviewable claim behind two findings of the
-[pilot differential](../../project/pilot-differential.md) — that we reserved
-words the grammars do not, and that we rejected state-machine notation they
-admit: every word we reserve and every state-machine construct we accept,
-checked against the pinned OMG grammars, with the resulting policy.
+[pilot differential](../../project/pilot-differential.md): that OpenSysML reserved
+words the grammars do not, and rejected state-machine notation they admit. It
+lists every reserved word and every accepted state-machine construct, checked
+against the pinned OMG grammars, with the resulting policy.
 
 ## Ground truth
 
@@ -17,15 +17,15 @@ from a sparse clone rather than vendored:
 - `org.omg.kerml.expressions.xtext/src/org/omg/kerml/expressions/xtext/KerMLExpressions.xtext` — cited as `KerMLExpressions.xtext`
 
 A word is *standard* when it appears as a quoted literal in one of those files,
-in the position we accept it. Line numbers are at the pin.
+in the position OpenSysML accepts it. Line numbers are at the pin.
 
 ## Verdict per word
 
 All eleven words below appear as a literal in **none** of the three grammars, at
 any line: they are not notation OMG defines, so reserving them only stopped
 models from using them as names. Each is now an ordinary name, matched
-contextually where our own notation needs it — the treatment `point`, `on` and
-`var` already get.
+contextually where OpenSysML's own notation requires it, which is the treatment
+`point`, `on` and `var` already receive.
 
 | Word | `KerML.xtext` | `SysML.xtext` | `KerMLExpressions.xtext` | Verdict |
 |------|---------------|---------------|--------------------------|---------|
@@ -44,7 +44,7 @@ contextually where our own notation needs it — the treatment `point`, `on` and
 `done` is the acceptance test that unreserving worked: the bundled normative
 library declares features named `done` (`Systems Library/Actions.sysml:50`,
 `Items.sysml:34`, `Parts.sysml:29`, `States.sysml:34`, `UseCases.sysml:28`) and
-references them (`Flows.sysml:57`, `:69`). We reported an error on every one.
+references them (`Flows.sysml:57`, `:69`). OpenSysML reported an error on every one.
 
 ### `done` is a library name, not notation
 
@@ -54,7 +54,7 @@ Example.sysml:32`, `Control Structures Example.sysml:27`, `35. Use Cases/Use
 Case Usage Example.sysml:35`) and `snapshot junked = done;`
 (`27. Occurrences/Time Slice and Snapshot Example.sysml:25`). Those are plain
 references to `Actions::Action::done`, a feature of the standard library, not a
-keyword. Our parser reads `done;` as an anonymous final node and `then done;`
+keyword. The parser reads `done;` as an anonymous final node and `then done;`
 as a succession targeting the `done` library feature. Both stay **silent**:
 warning on them would warn on OMG-authored files, which the classification
 forbids. In a state body `then done;` names the same library feature and states
@@ -208,5 +208,5 @@ disagree with them:
   body; a state with no outgoing transition does not complete on its own, because
   an ancestor or cross-region transition may still leave it.
 - **State-body `fork`/`join` silent.** They are action node literals, and
-  `StateBodyItem` admits a `BehaviorUsageMember`, so we read them as standard in
+  `StateBodyItem` admits a `BehaviorUsageMember`, so they are read as standard in
   a state body even though the pilot's state examples do not use them there.

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -50,8 +50,8 @@ gives no deadline guarantee, and nothing in it is scheduled: the runtime's step
 and time budgets bound how long an execution may run, which caps a worst case
 rather than promising one. Tails come from the Go garbage collector, the
 scheduler, TCP, and — for a cache miss — a parse whose cost scales with the
-document. Treat the p99 above as a soft budget, and measure your own p99 on your
-model sizes, cache state and concurrency before trusting one.
+document. Treat the p99 above as a soft budget, and measure the p99 for the
+relevant model sizes, cache state and concurrency before relying on it.
 
 What that means in practice:
 
@@ -61,12 +61,12 @@ What that means in practice:
   the service cache and costs ~0.5 ms, but asking the model itself (`model.eval`,
   `model.instantiate`, `model.execute_*`, which pass its hash) skips even that. The cache holds 100 models
   (`-cache-size`) and evicts least-recently-used, so a stream of distinct
-  sources will evict a model you still hold a hash for.
+  sources will evict a model whose hash is still held.
 - **Batch.** One RPC carrying many samples beats one RPC per sample; at ~0.5 ms
   of overhead per call, a per-sample loop tops out in the low thousands of calls
   per second per connection.
 - **Keep the hot loop local.** Filtering, thresholding and windowing over a
-  telemetry stream belong in NumPy in your own process. Use the service for the
+  telemetry stream belong in NumPy in the calling process. Use the service for the
   coarse-grained step — resolving a model question, instantiating, running an
   action or state machine, converting a model — not for every sample.
 - **Convert off the hot path.** Conversion re-parses its input on every call; it
@@ -199,9 +199,9 @@ dodge one.
   `TypedObject` provides (`instance`, `from_instance`, `sysml_id`) gets a trailing
   underscore (`instance_`); the SysML feature name it reads is unchanged.
 
-`opensysml.connect(host, port, auto_start=True)` returns a `Connection` of your
-own; the module-level functions share a lazily created singleton connection
-instead. Naming a host and port, writing `host:port` as the host, or setting
+`opensysml.connect(host, port, auto_start=True)` returns a caller-owned
+`Connection`; the module-level functions share a lazily created singleton
+connection instead. Naming a host and port, writing `host:port` as the host, or setting
 `$OPENSYSML_SERVICE=host:port`, is the opt-in to a service this client does not
 manage; with none of them the connection reaches a private child of this
 interpreter. A `host:port` address written as the host is read as one —
@@ -217,31 +217,31 @@ connections, stopped when the last is closed or the interpreter exits — and
 dies with that interpreter however it dies, because it exits at end of file on a
 stdin pipe only that process holds. Nothing about it is written to disk, so there
 is no record to authenticate, no pid outside its own `Popen` to signal, and no
-stale state for a later run to clean up. A connection to a service you manage
+stale state for a later run to clean up. A connection to a caller-managed service
 takes no reference and leaves it running, whatever it does.
 
-A service *you* manage is checked the way the cached binary is: it is asked what
+A caller-managed service is checked in the same way as the cached binary: it is asked what
 it is with `GetServerInfo`, and a release other than the one asked for raises
 `StaleServiceError` naming the mismatch and the remedy, instead of serving an old
 build whose first newer call fails as a `MissingCapabilityError`.
 `connect(version=…, require_capabilities=[…])` asks explicitly;
 `OPENSYSML_GRPC_VERSION` asks for a release for the binary cache and the running
 service alike, and with neither set whatever answers is accepted. Such a service
-is never stopped or replaced to satisfy the check — the remedy asks you to stop
-it, point the client elsewhere, or accept what is running — and the check stays
-lazy: a service of yours that is not listening yet is checked once it answers. A
+is never stopped or replaced to satisfy the check — the remedy is to stop it,
+point the client elsewhere, or accept what is running — and the check stays
+lazy: a caller-managed service that is not yet listening is checked once it answers. A
 private child cannot be a mismatch to begin with, since children are held per
 requirement, so a connection asking for another release starts its own rather
 than joining one. A service that only lacks a required *capability* is reported as
-`MissingCapabilityError`: capabilities come with a release, so the class you
-catch does not depend on who started the service.
+`MissingCapabilityError`: capabilities come with a release, so the class raised
+does not depend on who started the service.
 
 The client checks the advertised list before it makes a capability-gated call, so
 that error usually arrives without a round trip. When a call does reach a service
 that lacks the capability, the service refuses it with `UNIMPLEMENTED` naming the
 capability, and the client raises the same `MissingCapabilityError` with the gRPC
-error kept as its `__cause__` — so the class you catch does not depend on which
-side noticed either. A capability that only describes how a response is
+error kept as its `__cause__` — so the class raised does not depend on which
+side detected the problem either. A capability that only describes how a response is
 populated is not a refusal: the answer omits the fields it names, as documented
 per call.
 

--- a/docs/reference/rdf-mapping.md
+++ b/docs/reference/rdf-mapping.md
@@ -15,8 +15,8 @@ each of these is a deliberate property of it rather than a defect to report:
   74 are refused. See [Behavior](#behavior) and [Limitations](#limitations).
 - **The vocabulary may change without a compatibility path.** A graph written by
   one release may not read back into the next, and no migration is provided.
-  Treat a `.ttl` as an interchange artifact you can regenerate, not as the copy
-  of record.
+  Treat a `.ttl` as a regenerable interchange artifact rather than the copy of
+  record.
 - **Interoperability is not yet demonstrated**, and the gap is measured rather
   than argued. The `sysml:` vocabulary and the `elmt:` element base match Flexo
   MMS's `Namespaces.kt`; OpenSysML's ids — the part of an IRI after the final

--- a/docs/reference/repl-commands.md
+++ b/docs/reference/repl-commands.md
@@ -13,7 +13,7 @@ quoted segment holding a space and one in the middle of a chain: `%instantiate '
 | `%list` | List all declarations in current session |
 | `%clear` | Clear session (reset all declarations) |
 | `%load <path>...` | Submit the contents of files, directories or globs |
-| `%print [name]` | Print the session model as SysML notation at the prompt, or just the named element and its body (`%print 'My Pkg'::Car`). Comments are kept, since the same writer `%save` writes notation with is used, and what is printed can be typed back in. Notation only: nothing about RDF is reported. Reading the model materializes nothing and leaves a debugging session running |
+| `%print [name]` | Print the session model as SysML notation at the prompt, or only the named element and its body (`%print 'My Pkg'::Car`). Comments are kept, since the same writer `%save` writes notation with is used, and what is printed can be typed back in. Notation only: nothing about RDF is reported. Reading the model materializes nothing and leaves a debugging session running |
 | `%save <file>` | Write the session model to a file: `.sysml` notation (comments preserved) or `.ttl` RDF, which is [experimental](rdf-mapping.md#status-experimental) and reported as such on each save |
 | `%query <oslc-query>` | Identify model elements using OSLC Query text |
 | `%verbosity [level]` | Show or set output level: `quiet` (errors only), `normal`, `debug` (every diagnostic over the whole buffer) |

--- a/docs/reference/service-transports.md
+++ b/docs/reference/service-transports.md
@@ -64,8 +64,8 @@ exercised rather than described.
 
 ## Choose protobuf, not JSON
 
-**Protobuf is the body encoding for every client we ship or document. JSON is the debugging
-affordance.** This is not a style preference — it is the one strong measurement in the
+**Protobuf is the body encoding for every client shipped or documented by this project. JSON is
+the debugging affordance.** This is not a style preference; it is the strongest measurement in the
 evaluation:
 
 | 468 KB `Query` response | p50 | p95 | p99 |
@@ -181,7 +181,7 @@ default port instead. The prototype is kept, behind the flag, and tested — `in
 covers the protocol and `cmd/sysml-grpc` covers the binary answering a framed call — so that it
 cannot rot unnoticed while it is still in the tree.
 
-## Every protocol is tested, not just served
+## Every protocol is tested, not merely served
 
 A second protocol surface that no test drives rots. The conformance suite
 ([`conformance/`](https://github.com/Open-MBEE/OpenSysML/tree/main/conformance)) runs its whole

--- a/examples/PARSER_FEATURES_DEMOS.md
+++ b/examples/PARSER_FEATURES_DEMOS.md
@@ -304,4 +304,4 @@ These patterns appear throughout the official standard library:
 
 - Hand-written recursive descent parser (zero overhead, full error recovery)
 - Grammar source: OMG pilot Xtext grammars (SysML.xtext + KerMLExpressions)
-- Notation the reference accepts and we still reject is enumerated in [the pilot differential](../docs/project/pilot-differential.md)
+- Notation the reference accepts and OpenSysML still rejects is enumerated in [the pilot differential](../docs/project/pilot-differential.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,4 +34,5 @@ Each of these is a model and a walkthrough of the commands that exercise it.
 
 ## Other Examples
 
-Add your own example models here! SysML v2 files use `.sysml` extension, KerML files use `.kerml`.
+Additional example models may be added to this directory. SysML v2 files use the `.sysml`
+extension and KerML files use `.kerml`.

--- a/examples/disposal-robot-demo/README.md
+++ b/examples/disposal-robot-demo/README.md
@@ -56,7 +56,7 @@ the robot's draw.
 them, tallies what the call-out cost, and streams video home only if the power
 budget left room for it. The retrieval branch is a single node stating a flow of
 its own — the gripper closes, then the device is stowed — so the join waits for
-that whole flow, not just for the node to be entered.
+that whole flow, not merely for the node to be entered.
 
 ```bash
 ./bin/sysml examples/disposal-robot-demo/robot.sysml -action RobotBehavior::DisposalRun
@@ -361,7 +361,7 @@ conditions that conflict, minimally:
 ```
 
 `%configure` asks which robots the build constraint permits — one consistent
-selection, a selection you choose, or every one of them:
+selection, a caller-specified selection, or all of them:
 
 ```
 %configure RobotSolver::robotFamily::buildIsConsistent


### PR DESCRIPTION
## What and why

The root README opened with prose and no status row, so nothing above the fold said whether `main`
builds, what the quality gate says, or where the published packages are. Two badge rows now sit
under the title:

- CircleCI on `main`, and the SonarCloud quality gate, coverage, and the maintainability,
  reliability and security grades (all A, gate passing, coverage 81.5% as of this commit — the
  badges are live, not pinned).
- Latest GitHub release, pkg.go.dev, the PyPI version and its supported Python range, Apache-2.0,
  and <https://opensysml.org/>.

Deliberately omitted: npm, Maven Central and crates.io. Per docs/project/releasing.md the Node,
Java and Rust clients are not published yet, and a shields.io badge for an unpublished package
renders as `invalid` — they belong here once their first release tags land. The Go badge links to
the module root rather than `client/opensysml`, which pkg.go.dev will not have until the next core
tag.

The branch also merges `main` after the 0.4.1 changelog and the documentation prose pass landed.
One conflict, in the intro paragraph: that pass rewrote it while this branch added badges above it.
Resolved by keeping the rewritten prose verbatim and the badge rows above it — no wording from
either side is lost.

## Specification basis

Not applicable: documentation only, no behavior change.

## How it was verified

Every badge image and link target fetched by hand: each returns 200 and renders real content
(quality gate `passed`, coverage `81.5%`, ratings `A`, `release v0.4.0`, `pypi v0.3.2`,
`python 3.10 | 3.11 | 3.12 | 3.13`). `scripts/check-doc-links.py` reports 0 broken links and
`scripts/check-doc-ids.py` passes, both before and after the merge. No code touched.

## Checklist

- [ ] `make test` and `make lint` pass locally — n/a, README only
- [ ] Tests added or updated for the change — n/a, README only
- [x] Documentation extended where it already covers the surface (see CONTRIBUTING.md)
- [ ] `make docs-counts` run if a compliance row changed — n/a, no compliance row moved
- [x] No internal work-item labels (waves, slices, `F4`, `K5`) in the body, docs, or changelog
