### PR TITLE
ci(sonar): size the forked analysis JVM with SONAR_SCANNER_JAVA_OPTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,13 +401,13 @@ jobs:
     docker:
       - image: cimg/go:1.25
     # The Go sensor holds a whole directory's parse in memory; internal/core/runtime
-    # (168 files) overflows a 4 GB heap. 8 GB is the largest class in the project's
-    # plan (xlarge is rejected), so the heap below leaves ~1.5 GB for the Go parser.
+    # (168 files) overflows the default heap (a quarter of the container). 8 GB is
+    # the largest class in the project's plan (xlarge is rejected).
     resource_class: large
     environment:
-      # The pinned orb runs sonar-scanner-cli 8.0.1, whose launcher passes only
-      # $SONAR_SCANNER_OPTS to the JVM; SONAR_SCANNER_JAVA_OPTS is ignored there.
-      SONAR_SCANNER_OPTS: -Xmx6500m
+      # sonar-scanner-cli 8 forks the analysis into a second JVM whose arguments
+      # come from this variable only; SONAR_SCANNER_OPTS sizes just the launcher.
+      SONAR_SCANNER_JAVA_OPTS: -Xmx6500m
     steps:
       # Forked PRs get no context, so the token is absent there: end green
       # rather than fail every outside contribution. With a token, a failing
@@ -499,8 +499,8 @@ jobs:
               exit 0
             fi
             echo "sonar.projectVersion=${version#v}"
-            # The scanner reads JVM system properties, and this is the variable
-            # its launcher passes to the JVM (see the heap note above).
+            # The launcher JVM turns its sonar.* system properties into scanner
+            # properties and hands them to the forked analysis JVM.
             echo "export SONAR_SCANNER_OPTS=\"${SONAR_SCANNER_OPTS} -Dsonar.projectVersion=${version#v}\"" >> "$BASH_ENV"
 
       - sonarcloud/scan


### PR DESCRIPTION
sonar-scanner-cli 8 runs the engine in a second JVM whose options come from sonar.scanner.javaOpts (SONAR_SCANNER_JAVA_OPTS); SONAR_SCANNER_OPTS only reached the launcher, so every scan analysed with the default 2 GB heap.